### PR TITLE
Call G29 in M237 test, add G28 to end of M237 test

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -37,7 +37,7 @@ class MarlinTestCase(unittest.TestCase):
         for i in range(cycles):
             g.move(Z=1)
             g.write('G28')
-            g.write('M237')
+            g.write('G29')
             g.write('G1 F9000')
             for j, location in enumerate(measurement_locations):
                 print ".",
@@ -47,6 +47,9 @@ class MarlinTestCase(unittest.TestCase):
             stdev = np.std(measurements)
             msg = 'Bed level standard deviation was larger than 15 microns'
             self.assertLess(stdev, 15, msg)
+
+        # Home printer after M237 test
+        g.write('G28')
 
     def test_M218(self):
         # Assert offset echoed correctly


### PR DESCRIPTION
# Bugfix for `test_M237`
- M237 unit test now calls `G29` instead of `M237`
- `G28` called at end of M237 unit test to reset ABL rotation matrix
    - Before this change, if the M237 test was called before the M218 test, the M218 test would fail because the location returned after switching to T1 has a rotation matrix applied.