### PR TITLE
Handle paths with spaces and adjust _Version.h generation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Correct Syntax: ./build.sh [port [*upload | verify]]
 set -e
-HERE=$(pwd | sed 's/ /\\ /g')
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+HERE=$(echo $HERE | sed 's/ /\\ /g')
 VERSION='Voxel8 Marlin Build Script v1.0'
 
 # Begin build script
@@ -74,12 +75,16 @@ echo "#define STRING_DISTRIBUTION_DATE" `date '+"%Y-%m-%d %H:%M"'` >>"$OUTFILE"
     BRANCH=" $BRANCH"
   fi
   VERSION=`git describe --tags --first-parent 2>/dev/null`
+  HASH=`git rev-parse --short HEAD`
   VERSION_NUM=`git describe --tags --abbrev=0`
+  VERSION_NUM=$(echo $VERSION_NUM | sed 's/-.*//g')
+  VERSION_MIDDLE=$(echo $VERSION | sed "s/$VERSION_NUM-\(.*\)-g$HASH/\1/")
+  VERSION_COMMITS=$(echo $VERSION_MIDDLE | sed "s/.*-//")
   BRANCH=$(echo $BRANCH | sed 's/\//\\\//g')
   if [ "x$VERSION" != "x" ] ; then
     echo "#define BUILD_VERSION_NUMERIC \"$VERSION_NUM\"" >>"$OUTFILE"
-    echo "#define SHORT_BUILD_VERSION \"$VERSION\"" | sed "s/-.*/ $BRANCH$VERSION_MODIFIED\"/" >>"$OUTFILE"
-    echo "#define DETAILED_BUILD_VERSION \"$VERSION$VERSION_MODIFIED\"" | sed "s/-/ $BRANCH-/" >>"$OUTFILE"
+    echo "#define SHORT_BUILD_VERSION \"$VERSION_NUM $BRANCH$VERSION_MODIFIED\"" >>"$OUTFILE"
+    echo "#define DETAILED_BUILD_VERSION \"$VERSION_NUM $BRANCH-$VERSION_COMMITS-$HASH$VERSION_MODIFIED\"" >>"$OUTFILE"
   else
     VERSION=`git describe --tags --first-parent --always 2>/dev/null`
     echo "#define BUILD_VERSION_NUMERIC \"$VERSION_NUM\"" >>"$OUTFILE"
@@ -108,7 +113,8 @@ case "$(uname -s)"
   ;; Linux)
     # Future support for Linux
   ;; CYGWIN*)
-    CYGHERE="$(cygpath -aw $(pwd))"
+    CYGHERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cygpath -aw $(pwd) )"
+    CYGHERE=$(echo $CYGHERE | sed 's/ /\\ /g')
     ARDUINO_EXEC="C:/Program\ Files\ \(x86\)/Arduino/arduino_debug.exe $COMMAND \"$CYGHERE/Marlin/Marlin.ino\" --pref build.path=$HERE/build/ --pref board=rambo $PORT_ARG"
     ARDUINO_DEP="C:/Program Files (x86)/Arduino/hardware/arduino/avr"
   ;;MINGW32*|MINGW64*|MSYS*)

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 # Correct Syntax: ./build.sh [port [*upload | verify]]
 set -e
 HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-HERE=$(echo $HERE | sed 's/ /\\ /g')
+#HERE=$(echo $HERE | sed 's/ /\\ /g')
 VERSION='Voxel8 Marlin Build Script v1.0'
 
 # Begin build script
@@ -118,7 +118,7 @@ case "$(uname -s)"
     ARDUINO_EXEC="C:/Program\ Files\ \(x86\)/Arduino/arduino_debug.exe $COMMAND \"$CYGHERE/Marlin/Marlin.ino\" --pref build.path=$HERE/build/ --pref board=rambo $PORT_ARG"
     ARDUINO_DEP="C:/Program Files (x86)/Arduino/hardware/arduino/avr"
   ;;MINGW32*|MINGW64*|MSYS*)
-    ARDUINO_EXEC="C:/Program\ Files\ \(x86\)/Arduino/arduino_debug.exe $COMMAND $HERE/Marlin/Marlin.ino --pref build.path=$HERE/build/ --pref board=rambo $PORT_ARG"
+    ARDUINO_EXEC="C:/Program\ Files\ \(x86\)/Arduino/arduino_debug.exe $COMMAND \"$HERE/Marlin/Marlin.ino\" --pref \"build.path=$HERE/build/\" --pref board=rambo $PORT_ARG"
     ARDUINO_DEP="C:/Program Files (x86)/Arduino/hardware/arduino/avr"
   ;; *)
     echo 'This operating system is unfamiliar'

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Correct Syntax: ./build.sh [port [*upload | verify]]
 set -e
-HERE=$(pwd)
+HERE=$(pwd | sed 's/ /\\ /g')
 VERSION='Voxel8 Marlin Build Script v1.0'
 
 # Begin build script

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,6 @@
 # Correct Syntax: ./build.sh [port [*upload | verify]]
 set -e
 HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-#HERE=$(echo $HERE | sed 's/ /\\ /g')
 VERSION='Voxel8 Marlin Build Script v1.0'
 
 # Begin build script
@@ -108,17 +107,16 @@ echo ""
 
 case "$(uname -s)"
   in Darwin)
-    ARDUINO_EXEC="/Applications/Arduino.app/Contents/MacOS/Arduino $COMMAND $HERE/Marlin/Marlin.ino --pref build.path=$HERE/build/ --pref board=rambo $PORT_ARG"
+    ARDUINO_EXEC="/Applications/Arduino.app/Contents/MacOS/Arduino $COMMAND \"$HERE/Marlin/Marlin.ino\" --pref build.path=\"$HERE/build/\" --pref board=rambo $PORT_ARG"
     ARDUINO_DEP="/Applications/Arduino.app/Contents/Java/hardware/arduino/avr/"
   ;; Linux)
     # Future support for Linux
   ;; CYGWIN*)
     CYGHERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cygpath -aw $(pwd) )"
-    CYGHERE=$(echo $CYGHERE | sed 's/ /\\ /g')
-    ARDUINO_EXEC="C:/Program\ Files\ \(x86\)/Arduino/arduino_debug.exe $COMMAND \"$CYGHERE/Marlin/Marlin.ino\" --pref build.path=$HERE/build/ --pref board=rambo $PORT_ARG"
+    ARDUINO_EXEC="C:/Program\ Files\ \(x86\)/Arduino/arduino_debug.exe $COMMAND \"$CYGHERE/Marlin/Marlin.ino\" --pref build.path=\"$HERE/build/\" --pref board=rambo $PORT_ARG"
     ARDUINO_DEP="C:/Program Files (x86)/Arduino/hardware/arduino/avr"
   ;;MINGW32*|MINGW64*|MSYS*)
-    ARDUINO_EXEC="C:/Program\ Files\ \(x86\)/Arduino/arduino_debug.exe $COMMAND \"$HERE/Marlin/Marlin.ino\" --pref \"build.path=$HERE/build/\" --pref board=rambo $PORT_ARG"
+    ARDUINO_EXEC="C:/Program\ Files\ \(x86\)/Arduino/arduino_debug.exe $COMMAND \"$HERE/Marlin/Marlin.ino\" --pref build.path=\"$HERE/build/\" --pref board=rambo $PORT_ARG"
     ARDUINO_DEP="C:/Program Files (x86)/Arduino/hardware/arduino/avr"
   ;; *)
     echo 'This operating system is unfamiliar'


### PR DESCRIPTION
This is so that people who have spaces in their Windows usernames.

This gives more control of the different parts of the version file such as numeric version, commit number, and hash all as separate variables.