### PR TITLE
Kd/bugfix bed size

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -508,7 +508,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define Y_MIN_POS 0
 #define Z_MIN_POS 0
 #define X_MAX_POS 188
-#define Y_MAX_POS 180
+#define Y_MAX_POS 178
 #define Z_MAX_POS 105
 
 //===========================================================================

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -507,9 +507,9 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define X_MIN_POS 0
 #define Y_MIN_POS 0
 #define Z_MIN_POS 0
-#define X_MAX_POS 190
+#define X_MAX_POS 188
 #define Y_MAX_POS 180
-#define Z_MAX_POS 112
+#define Z_MAX_POS 105
 
 //===========================================================================
 //========================= Filament Runout Sensor ==========================


### PR DESCRIPTION
Printers have been crashin in all axis. This update gives 1mm margin in X, and 5mm margin in Y and Z.

The slicing configs need to be updated in accordance.

