### PR TITLE
Adjust Thermal Runaway

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -260,9 +260,9 @@ Here are some standard links for getting your machine calibrated:
 //  #define  DEFAULT_Kd 66.91
     
 // E3D V6 with PT100
-    #define  DEFAULT_Kp 18.37
-    #define  DEFAULT_Ki 0.95
-    #define  DEFAULT_Kd 67.89
+    #define  DEFAULT_Kp 19.96
+    #define  DEFAULT_Ki 1.24
+    #define  DEFAULT_Kd 80.47
 
 // D3D 24V New Heat Block
 //    #define  DEFAULT_Kp 9.83

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -358,8 +358,8 @@ Here are some standard links for getting your machine calibrated:
  * the firmware will halt as a safety precaution.
  */
 
-#define THERMAL_PROTECTION_HOTENDS // Enable thermal protection for all extruders
-#define THERMAL_PROTECTION_BED     // Enable thermal protection for the heated bed
+//#define THERMAL_PROTECTION_HOTENDS // Enable thermal protection for all extruders
+//#define THERMAL_PROTECTION_BED     // Enable thermal protection for the heated bed
 
 //===========================================================================
 //============================ Pneumatics Settings ==========================

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -228,7 +228,7 @@ Here are some standard links for getting your machine calibrated:
   //#define SLOW_PWM_HEATERS // PWM with very low frequency (roughly 0.125Hz=8s) and minimum state time of approximately 1s useful for heaters driven by a relay
   //#define PID_PARAMS_PER_EXTRUDER // Uses separate PID parameters for each extruder (useful for mismatched extruders)
                                     // Set/get with gcode: M301 E[extruder number, 0-2]
-  #define PID_FUNCTIONAL_RANGE 10 // If the temperature difference between the target temperature and the actual temperature
+  #define PID_FUNCTIONAL_RANGE 30 // If the temperature difference between the target temperature and the actual temperature
                                   // is more then PID_FUNCTIONAL_RANGE then the PID will be shut off and the heater will be set to min/max.
   #define PID_INTEGRAL_DRIVE_MAX PID_MAX  //limit for the integral term
   #define K1 0.95 //smoothing factor within the PID
@@ -259,7 +259,7 @@ Here are some standard links for getting your machine calibrated:
 //  #define  DEFAULT_Ki 1.92
 //  #define  DEFAULT_Kd 66.91
     
-// E3D V6 with PT100
+// E3D V6 24V with PT100
     #define  DEFAULT_Kp 19.96
     #define  DEFAULT_Ki 1.24
     #define  DEFAULT_Kd 80.47

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -358,8 +358,8 @@ Here are some standard links for getting your machine calibrated:
  * the firmware will halt as a safety precaution.
  */
 
-//#define THERMAL_PROTECTION_HOTENDS // Enable thermal protection for all extruders
-//#define THERMAL_PROTECTION_BED     // Enable thermal protection for the heated bed
+#define THERMAL_PROTECTION_HOTENDS // Enable thermal protection for all extruders
+#define THERMAL_PROTECTION_BED     // Enable thermal protection for the heated bed
 
 //===========================================================================
 //============================ Pneumatics Settings ==========================

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -36,7 +36,7 @@
   #define THERMAL_PROTECTION_BED_HYSTERESIS 10// Degrees Celsius
 #endif
 
-#define TEMP_ERROR_INTERVAL 100       //ms between temp error checks
+#define TEMP_ERROR_INTERVAL 500       //ms between temp error checks
 #define TEMP_BED_ERROR_INTERVAL 1000
 
 #if ENABLED(PIDTEMP)

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -18,7 +18,7 @@
  * Thermal Protection parameters
  */
 #if ENABLED(THERMAL_PROTECTION_HOTENDS)
-  #define THERMAL_PROTECTION_PERIOD 40        // Seconds
+  #define THERMAL_PROTECTION_PERIOD 100       // Seconds
   #define THERMAL_PROTECTION_HYSTERESIS 10    // Degrees Celsius
 
   /**
@@ -27,12 +27,12 @@
    * degrees, the machine is halted, requiring a hard reset. This test restarts with any M104/M109,
    * but only if the current temperature is far enough below the target for a reliable test.
    */
-  #define WATCH_TEMP_PERIOD 30                // Seconds
+  #define WATCH_TEMP_PERIOD 100               // Seconds
   #define WATCH_TEMP_INCREASE 10              // Degrees Celsius
 #endif
 
 #if ENABLED(THERMAL_PROTECTION_BED)
-  #define THERMAL_PROTECTION_BED_PERIOD 60    // Seconds
+  #define THERMAL_PROTECTION_BED_PERIOD 100   // Seconds
   #define THERMAL_PROTECTION_BED_HYSTERESIS 10// Degrees Celsius
 #endif
 


### PR DESCRIPTION
# Adjust Thermal Runaway Protection

This PR modifies the thermal runaway protection settings in order to provide more time for the hotend and bed to reach target temps without throwing errors.

A unit test is still being written for thermal runaway. It will be added in a separate PR.

