### PR TITLE
Add .build_log to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ build/
 .build/
 lib/
 libraries/
-src/
+src
 .ropeproject
 *.pyc
 .build_log

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ libraries/
 src/
 .ropeproject
 *.pyc
+.build_log


### PR DESCRIPTION
This is the build log output needed for the firmware update OctoPrint plugin.