### PR TITLE
Remove moving Z-axis before G29

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -558,8 +558,6 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 
 #if ENABLED(AUTO_BED_LEVELING_FEATURE)
 
-  #define BED_LEVEL_PROBE_Z 3 // Height at which to probe z-axis
-
   // There are 2 different ways to specify probing locations:
   //
   // - "grid" mode

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5078,11 +5078,7 @@ inline void gcode_M226() {
   
     setup_for_endstop_move();
     feedrate = homing_feedrate[Z_AXIS];
-  
-    // Adjust z-axis to specified height
-    destination[Z_AXIS] = BED_LEVEL_PROBE_Z;
-    prepare_move();
-  
+
     float levelProbe_1 = bed_level_probe_pt(ABL_PROBE_PT_1_X - X_PROBE_OFFSET_FROM_EXTRUDER, ABL_PROBE_PT_1_Y - Y_PROBE_OFFSET_FROM_EXTRUDER, current_position[Z_AXIS], verbose_level),
           levelProbe_2 = bed_level_probe_pt(ABL_PROBE_PT_2_X - X_PROBE_OFFSET_FROM_EXTRUDER, ABL_PROBE_PT_2_Y - Y_PROBE_OFFSET_FROM_EXTRUDER, current_position[Z_AXIS], verbose_level),
           levelProbe_3 = bed_level_probe_pt(ABL_PROBE_PT_3_X - X_PROBE_OFFSET_FROM_EXTRUDER, ABL_PROBE_PT_3_Y - Y_PROBE_OFFSET_FROM_EXTRUDER, current_position[Z_AXIS], verbose_level);


### PR DESCRIPTION
This removes the move to a set Z-axis destination before continuing with G29. This move was causing an issue with the alignment script.
I need some time to look more into the reasoning behind the issue.

cc: @jminardi @kdumontnu 