### PR TITLE
rr/feature house air

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -405,7 +405,7 @@ Here are some standard links for getting your machine calibrated:
   // If the pressure goes above this value the pump will be turned off. This prevents
   // the tank from being overpressurized. This value has units of PSI * 10 (to eliminate
   // floating point numbers in the lookup table).
-  #define PNEUMATIC_MAX 500
+  #define PNEUMATIC_MAX 1000 // 100 psi
 #endif
 
 //===========================================================================

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -130,6 +130,9 @@
 
 #if ENABLED(E_REGULATOR)
   #define REGULATOR_CHECK_INTERVAL 2500 // in ms
+
+  // If tank pressure is greater than this number, house air is assumed
+  #define HOUSE_AIR_THRESH    42 // 42 psi
 #endif
 
 //===========================================================================

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -131,7 +131,9 @@
 #if ENABLED(E_REGULATOR)
   #define REGULATOR_CHECK_INTERVAL 2500 // in ms
 
-  // If tank pressure is greater than this number, house air is assumed
+  // If tank pressure is greater than this number, house air is assumed.
+  // In this case, a tank setpoint is no longer required and if a setpoint
+  // exist, it is not considered when calculating available pressures
   #define HOUSE_AIR_THRESH    42 // 42 psi
 #endif
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4956,7 +4956,7 @@ inline void gcode_M226() {
    * M236 - Send Value to ADC w/ no EEPROM write
    */
   inline void gcode_M236() {
-    uint16_t current_tank = (uint8_t)pressurePneumatic();
+    uint16_t current_tank = (uint16_t)pressurePneumatic();
     uint8_t current_tank_target = (uint8_t)targetPneumatic();
     uint16_t available_output_pressure = (current_tank - PNEUMATIC_HYSTERESIS_PSI);
     float actual_output_pressure = pressureRegulator();

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4956,7 +4956,7 @@ inline void gcode_M226() {
    * M236 - Send Value to ADC w/ no EEPROM write
    */
   inline void gcode_M236() {
-    uint8_t current_tank = (uint8_t)pressurePneumatic();
+    uint16_t current_tank = (uint8_t)pressurePneumatic();
     uint8_t current_tank_target = (uint8_t)targetPneumatic();
     uint16_t available_output_pressure = (current_tank - PNEUMATIC_HYSTERESIS_PSI);
     float actual_output_pressure = pressureRegulator();
@@ -5019,7 +5019,11 @@ inline void gcode_M226() {
       else {
         SERIAL_PROTOCOLLNPGM("Internal Pump");
       }
-      // Display available pressure
+      // Display actual tank pressure
+      SERIAL_PROTOCOLPGM("Actual Tank Pressure: ");
+      SERIAL_PROTOCOL(current_tank);
+      SERIAL_PROTOCOLLNPGM(" psi");
+      // Display available tank pressure
       SERIAL_PROTOCOLPGM("Available Tank Pressure: ");
       SERIAL_PROTOCOL(available_output_pressure);
       SERIAL_PROTOCOLLNPGM(" psi");

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4963,7 +4963,7 @@ inline void gcode_M226() {
       float psi = code_value();
       // Desired pressure outside allowed range?
       if((psi > OUTPUT_PSI_MAX) || (psi < OUTPUT_PSI_MIN)) {
-        SERIAL_PROTOCOLPGM("WARNING: Desired Pressure Outside Allowed Pressure Range (");
+        SERIAL_PROTOCOLPGM("ERROR: Desired Pressure Outside Allowed Pressure Range (");
         SERIAL_PROTOCOL(OUTPUT_PSI_MIN);
         SERIAL_PROTOCOLPGM(" - ");
         SERIAL_PROTOCOL(OUTPUT_PSI_MAX);
@@ -4987,7 +4987,7 @@ inline void gcode_M226() {
             available_output_pressure = 0;
           }
           // Display available pressure
-          SERIAL_PROTOCOLLNPGM("WARNING: Insufficient tank pressure");
+          SERIAL_PROTOCOLLNPGM("ERROR: Insufficient tank pressure");
           SERIAL_PROTOCOLPGM("Available Pressure: ");
           SERIAL_PROTOCOL(available_output_pressure);
           SERIAL_PROTOCOLPGM(" psi");
@@ -5014,7 +5014,7 @@ inline void gcode_M226() {
           else if (current_tank_target < current_tank) {
             available_output_pressure = (current_tank_target - PNEUMATIC_HYSTERESIS_PSI);
           }
-          SERIAL_PROTOCOLLNPGM("WARNING: Insufficient tank pressure");
+          SERIAL_PROTOCOLLNPGM("ERROR: Insufficient tank pressure");
           SERIAL_PROTOCOLPGM("Available Tank Pressure: ");
           SERIAL_PROTOCOL(available_output_pressure);
           SERIAL_PROTOCOLPGM(" psi");

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5032,7 +5032,6 @@ inline void gcode_M226() {
     }
     // Return current output pressure if no desired pressure given
     else {
-      SERIAL_PROTOCOLPGM("ok ");
       SERIAL_PROTOCOL(actual_output_pressure);
     }
     SERIAL_EOL;

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4954,10 +4954,10 @@ inline void gcode_M226() {
   inline void gcode_M236() {
     uint8_t current_tank = (uint8_t)pressurePneumatic();
     uint8_t current_tank_target = (uint8_t)targetPneumatic();
-    uint8_t house_air = FALSE;
+    uint8_t house_air = false;
     // Check for house air
     if(current_tank > HOUSE_AIR_THRESH) {
-      house_air = TRUE;
+      house_air = true;
     }
     if(code_seen('S')) {
       float psi = code_value();

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4961,7 +4961,6 @@ inline void gcode_M226() {
     }
     if(code_seen('S')) {
       float psi = code_value();
-      }
       // Desired pressure outside allowed range?
       if((psi > OUTPUT_PSI_MAX) || (psi < OUTPUT_PSI_MIN)) {
         SERIAL_PROTOCOLPGM("WARNING: Desired Pressure Outside Allowed Pressure Range (");

--- a/Marlin/Regulator.h
+++ b/Marlin/Regulator.h
@@ -17,7 +17,7 @@
 #define REG_OFFSET      0.5 // psi
 #define REG_HYSTERESIS  0.2 // psi
 #define MCP_CONST       (REG_OFFSET - (REG_HYSTERESIS/2.0))
-#define REGULATOR_LOW_P 1
+#define REGULATOR_LOW_P 2
 
 /*================================================================================*/
 /* Function Prototypes */

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -280,60 +280,63 @@
   /**
    * Test Heater, Temp Sensor, and Extruder Pins; Sensor Type must also be set.
    */
-  #if EXTRUDERS > 3
-    #if !HAS_HEATER_3
-      #error HEATER_3_PIN not defined for this board.
-    #elif !PIN_EXISTS(TEMP_3)
-      #error TEMP_3_PIN not defined for this board.
-    #elif !PIN_EXISTS(E3_STEP) || !PIN_EXISTS(E3_DIR) || !PIN_EXISTS(E3_ENABLE)
-      #error E3_STEP_PIN, E3_DIR_PIN, or E3_ENABLE_PIN not defined for this board.
-    #elif TEMP_SENSOR_3 == 0
-      #error TEMP_SENSOR_3 is required with 4 EXTRUDERS.
-    #endif
-  #elif EXTRUDERS > 2
-    #if !HAS_HEATER_2
-      #error HEATER_2_PIN not defined for this board.
-    #elif !PIN_EXISTS(TEMP_2)
-      #error TEMP_2_PIN not defined for this board.
-    #elif !PIN_EXISTS(E2_STEP) || !PIN_EXISTS(E2_DIR) || !PIN_EXISTS(E2_ENABLE)
-      #error E2_STEP_PIN, E2_DIR_PIN, or E2_ENABLE_PIN not defined for this board.
-    #elif TEMP_SENSOR_2 == 0
-      #error TEMP_SENSOR_2 is required with 3 or more EXTRUDERS.
-    #endif
-  #elif EXTRUDERS > 1
-    #if !PIN_EXISTS(TEMP_1)
-      #error TEMP_1_PIN not defined for this board.
-    #elif !PIN_EXISTS(E1_STEP) || !PIN_EXISTS(E1_DIR) || !PIN_EXISTS(E1_ENABLE)
-      #error E1_STEP_PIN, E1_DIR_PIN, or E1_ENABLE_PIN not defined for this board.
-    #endif
-  #endif
 
-  #if EXTRUDERS > 1 || ENABLED(HEATERS_PARALLEL)
-    // Pneumatics do not require a heater
-    #if (!HAS_HEATER_1 && DISABLED(PNEUMATICS))
-      #error HEATER_1_PIN not defined for this board.
+  // (Dual) Pneumatics do not require temp sensors/heaters
+  #if DISABLED(PNEUMATICS)
+
+    #if EXTRUDERS > 3
+      #if !HAS_HEATER_3
+        #error HEATER_3_PIN not defined for this board.
+      #elif !PIN_EXISTS(TEMP_3)
+        #error TEMP_3_PIN not defined for this board.
+      #elif !PIN_EXISTS(E3_STEP) || !PIN_EXISTS(E3_DIR) || !PIN_EXISTS(E3_ENABLE)
+        #error E3_STEP_PIN, E3_DIR_PIN, or E3_ENABLE_PIN not defined for this board.
+      #elif TEMP_SENSOR_3 == 0
+        #error TEMP_SENSOR_3 is required with 4 EXTRUDERS.
+      #endif
+    #elif EXTRUDERS > 2
+      #if !HAS_HEATER_2
+        #error HEATER_2_PIN not defined for this board.
+      #elif !PIN_EXISTS(TEMP_2)
+        #error TEMP_2_PIN not defined for this board.
+      #elif !PIN_EXISTS(E2_STEP) || !PIN_EXISTS(E2_DIR) || !PIN_EXISTS(E2_ENABLE)
+        #error E2_STEP_PIN, E2_DIR_PIN, or E2_ENABLE_PIN not defined for this board.
+      #elif TEMP_SENSOR_2 == 0
+        #error TEMP_SENSOR_2 is required with 3 or more EXTRUDERS.
+      #endif
+    #elif EXTRUDERS > 1
+      #if !PIN_EXISTS(TEMP_1)
+        #error TEMP_1_PIN not defined for this board.
+      #elif !PIN_EXISTS(E1_STEP) || !PIN_EXISTS(E1_DIR) || !PIN_EXISTS(E1_ENABLE)
+        #error E1_STEP_PIN, E1_DIR_PIN, or E1_ENABLE_PIN not defined for this board.
+      #endif
     #endif
-  #endif
 
-  #if TEMP_SENSOR_1 == 0
-   // Pneumatics do not require a temp sensor
-    #if (EXTRUDERS > 1 && DISABLED(PNEUMATICS))
-      #error TEMP_SENSOR_1 is required with 2 or more EXTRUDERS.
-    #elif ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
-      #error TEMP_SENSOR_1 is required with TEMP_SENSOR_1_AS_REDUNDANT.
+    #if EXTRUDERS > 1 || ENABLED(HEATERS_PARALLEL)
+      #if !HAS_HEATER_1
+        #error HEATER_1_PIN not defined for this board.
+      #endif
     #endif
-  #endif
 
-  #if !HAS_HEATER_0
-    #error HEATER_0_PIN not defined for this board.
-  #elif !PIN_EXISTS(TEMP_0)
-    #error TEMP_0_PIN not defined for this board.
-  #elif !PIN_EXISTS(E0_STEP) || !PIN_EXISTS(E0_DIR) || !PIN_EXISTS(E0_ENABLE)
-    #error E0_STEP_PIN, E0_DIR_PIN, or E0_ENABLE_PIN not defined for this board.
-  #elif TEMP_SENSOR_0 == 0
-    #error TEMP_SENSOR_0 is required.
-  #endif
+    #if TEMP_SENSOR_1 == 0
+      #if EXTRUDERS > 1
+        #error TEMP_SENSOR_1 is required with 2 or more EXTRUDERS.
+      #elif ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
+        #error TEMP_SENSOR_1 is required with TEMP_SENSOR_1_AS_REDUNDANT.
+      #endif
+    #endif
 
+    #if !HAS_HEATER_0
+      #error HEATER_0_PIN not defined for this board.
+    #elif !PIN_EXISTS(TEMP_0)
+      #error TEMP_0_PIN not defined for this board.
+    #elif !PIN_EXISTS(E0_STEP) || !PIN_EXISTS(E0_DIR) || !PIN_EXISTS(E0_ENABLE)
+      #error E0_STEP_PIN, E0_DIR_PIN, or E0_ENABLE_PIN not defined for this board.
+    #elif TEMP_SENSOR_0 == 0
+      #error TEMP_SENSOR_0 is required.
+    #endif
+
+  #endif // DISABLED(PNEUMATICS)
   /**
    * Warnings for old configurations
    */

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -247,6 +247,10 @@ class MarlinTestCase(unittest.TestCase):
         status = g.write('M236 V', resp_needed=True)
         self.assertIn('House Air', resp)
 
+        # Reset printer to previous state
+        g.write('M236 S0')
+        g.write('M125 S0')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,7 +27,7 @@ class MarlinTestCase(unittest.TestCase):
 
     ###########################################################################
     #
-    #                          Function Definitions
+    #                                 Methods
     #
     ###########################################################################
 
@@ -55,12 +55,10 @@ class MarlinTestCase(unittest.TestCase):
             if (float(resp.split('P:')[1].split()[0]) >= desired_pressure):
                 break
             elif (time_passed >= timeout):
-                print('ERROR: Timeout while waiting for pressurization')
-                break
+                raise RuntimeError('Timeout while waiting for pressurization')
             else:
                 sleep(1)
                 time_passed += 1
-        return None
 
     ###########################################################################
     #
@@ -197,7 +195,7 @@ class MarlinTestCase(unittest.TestCase):
         status = g.write('M236 V', resp_needed=True)
 
         # Check that tank is near 0 psi first
-        if (status.split()[7] <= pressure_near_zero):
+        if (int(status.split()[7]) <= pressure_near_zero):
             # Assert that available tank pressure is 0 psi when tank near 0 psi
             resp = g.write('M236 S' + str(pressure_setpoint), resp_needed=True)
             self.assertIn('Available Tank Pressure: 0 psi', resp)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,8 +14,8 @@ class MarlinTestCase(unittest.TestCase):
             aerotech_include=False,
             direct_write=True,
             direct_write_mode='serial',
-            printer_port="/dev/tty.usbmodem1421",
-            #printer_port="COM14",
+            #printer_port="/dev/tty.usbmodem1421",
+            printer_port="COM4",
         )
 
     def tearDown(self):
@@ -43,7 +43,7 @@ class MarlinTestCase(unittest.TestCase):
 
     def set_tank_pressure(self, desired_pressure):
         g = self.g
-        timeout = 60
+        timeout = 90
         time_passed = 0
 
         g.write('M125 S' + str(desired_pressure))
@@ -231,7 +231,7 @@ class MarlinTestCase(unittest.TestCase):
 
         status = g.write('M236 V', resp_needed=True)
         self.assertIn('Output Pressure Set Point: ' +
-                      str(pressure_setpoint - pressure_buffer))
+                      str(pressure_setpoint - pressure_buffer), status)
 
         # Assert that pressure range cannot be exceeded without errors
         resp = g.write('M236 S' + str(pressure_lower_bound), resp_needed=True)
@@ -245,7 +245,7 @@ class MarlinTestCase(unittest.TestCase):
 
         # Assert that airsource identified as house air
         status = g.write('M236 V', resp_needed=True)
-        self.assertIn('House Air', resp)
+        self.assertIn('House Air', status)
 
         # Reset printer to previous state
         g.write('M236 S0')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -54,7 +54,7 @@ class MarlinTestCase(unittest.TestCase):
             # ok T:25.0 /0.0 B:0.0 /0.0 T0:25.0 /0.0 T1:0.0 /0.0 P:35.7 /0.0 ...
             if (float(resp.split('P:')[1].split()[0]) >= desired_pressure):
                 break
-            else if(time_passed >= timeout):
+            elif (time_passed >= timeout):
                 print('ERROR: Timeout while waiting for pressurization')
                 break
             else:
@@ -187,6 +187,7 @@ class MarlinTestCase(unittest.TestCase):
 
         # Pressure Definitions
         pressure_setpoint = 10
+        pressure_house_air = 45
         pressure_buffer = 2
         pressure_upper_bound = 131
         pressure_lower_bound = -1
@@ -219,7 +220,7 @@ class MarlinTestCase(unittest.TestCase):
 
         # Assert that setpoint must be <= (tank_target - 2 psi)
         for i in range(0, pressure_buffer):
-            resp = g.write('M236 S' + str(pressure_setpoint - i)),
+            resp = g.write('M236 S' + str(pressure_setpoint - i),
                            resp_needed=True)
             self.assertIn('ERROR: Insufficient tank pressure', resp)
 
@@ -239,7 +240,12 @@ class MarlinTestCase(unittest.TestCase):
         resp = g.write('M236 S' + str(pressure_upper_bound), resp_needed=True)
         self.assertIn('Outside Allowed Pressure Range', resp)
 
-        #
+        # Imitate house air with ~45 psi
+        self.set_tank_pressure(pressure_house_air)
+
+        # Assert that airsource identified as house air
+        status = g.write('M236 V', resp_needed=True)
+        self.assertIn('House Air', resp)
 
 
 if __name__ == '__main__':

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -51,7 +51,7 @@ class MarlinTestCase(unittest.TestCase):
         while (True):
             resp = g.write('M105', resp_needed=True)
             # String returned is of the form:
-            # ok T:25.0 /0.0 B:0.0 /0.0 T0:25.0 /0.0 T1:0.0 /0.0 P:35.7 /0.0 ...
+            # ok T:25.0 /0.0 B:0.0 /0.0 T0:25.0 /0.0 T1:0.0 /0.0 P:35.7 /0.0...
             if (float(resp.split('P:')[1].split()[0]) >= desired_pressure):
                 break
             elif (time_passed >= timeout):
@@ -60,7 +60,7 @@ class MarlinTestCase(unittest.TestCase):
             else:
                 sleep(1)
                 time_passed += 1
-
+        return None
 
     ###########################################################################
     #
@@ -203,7 +203,7 @@ class MarlinTestCase(unittest.TestCase):
             self.assertIn('Available Tank Pressure: 0 psi', resp)
 
             status = g.write('M236 V', resp_needed=True)
-            self.assertIn('Output Pressure Set Point: 0.00',status)
+            self.assertIn('Output Pressure Set Point: 0.00', status)
 
             # Assert that setpoint of 0 psi is valid when tank near 0 psi
             resp = g.write('M236 S0', resp_needed=True)


### PR DESCRIPTION
#  Automatically Detect House Air
![asdfasdf](https://cloud.githubusercontent.com/assets/13026720/11199161/33d52858-8c99-11e5-901c-55effa1782f3.jpg)

## Main Changes
- `PNEUMATIC_MAX` was changed from 50 psi to 100 psi
- In SanityCheck.h, errors for heaters and temp pins are only generated if `PNEUMATICS` is disabled
- M236 now determines if house air is being used by comparing the tank pressure with a predefined threshold.
     - Low pressure constant changed from 1 psi to 2 psi b/c if current tank pressure is 2, pneumatic hysteresis is also 2, so it will say 2 - 2 = 0 psi is available.
     - `HOUSE_AIR_THRESH` is defined as 42 psi in Configuration_adv.h. If tank is greater than this value, house air is likely being used. 


Fixes #67 (House air issue)

cc @jminardi @kevingelion @kdumontnu 