### PR TITLE
Disable Bed Thermal Runaway

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -359,7 +359,7 @@ Here are some standard links for getting your machine calibrated:
  */
 
 #define THERMAL_PROTECTION_HOTENDS // Enable thermal protection for all extruders
-#define THERMAL_PROTECTION_BED     // Enable thermal protection for the heated bed
+//#define THERMAL_PROTECTION_BED     // Enable thermal protection for the heated bed
 
 //===========================================================================
 //============================ Pneumatics Settings ==========================


### PR DESCRIPTION
The only change here is undefining `THERMAL_PROTECTION_BED` in Configuration.h because prints are killed when removing the bed for component insertion.

cc @jminardi @kdumontnu @kevingelion 