### PR TITLE
Conditional compilation for solenoids

### DIFF
--- a/Marlin/pins_VOXEL8_GEN3C.h
+++ b/Marlin/pins_VOXEL8_GEN3C.h
@@ -112,8 +112,10 @@ DIGITAL POTENTIOMETER PINS
 /*************************
     SOLENOID PINS
 *************************/
-#define SOL0_PIN                -1 // Set to CART0_SIG0_PIN for pneumatics in CART0
-#define SOL1_PIN                CART1_SIG0_PIN
+#if ENABLED(PNEUMATICS)
+  #define SOL0_PIN                -1 // Set to CART0_SIG0_PIN for pneumatics in CART0
+  #define SOL1_PIN                CART1_SIG0_PIN
+#endif
 
 
 #define E0_STEP_PIN             34


### PR DESCRIPTION
The only change here is putting `#if ENABLED(PNEUMATICS)` and `#endif` around solenoid pin definitions. Without it, there were compilation errors if pneumatics was not defined. 