### PR TITLE
[WIP] X Homing Direction Based on Conditional Compilation

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -497,9 +497,15 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 // ENDSTOP SETTINGS:
 // Sets direction of endstops when homing; 1=MAX, -1=MIN
 // :[-1,1]
-#define X_HOME_DIR -1
-#define Y_HOME_DIR 1
-#define Z_HOME_DIR -1
+#if MOTHERBOARD == BOARD_VOXEL8_GEN3C2
+  #define X_HOME_DIR -1
+  #define Y_HOME_DIR 1
+  #define Z_HOME_DIR -1
+#else // GEN3C and before
+  #define X_HOME_DIR 1
+  #define Y_HOME_DIR 1
+  #define Z_HOME_DIR -1
+#endif
 
 #define min_software_endstops true // If true, axis won't move to coordinates less than HOME_POS.
 #define max_software_endstops true  // If true, axis won't move to coordinates greater than the defined lengths below.

--- a/Marlin/boards.h
+++ b/Marlin/boards.h
@@ -57,7 +57,8 @@
 #define BOARD_BAM_DICE          401  // 2PrintBeta BAM&DICE with STK drivers
 #define BOARD_BAM_DICE_DUE      402  // 2PrintBeta BAM&DICE Due with STK drivers
 #define BOARD_VOXEL8_GEN3B      801  // Voxel8 Gen3B Printer
-#define BOARD_VOXEL8_GEN3C2     802  // Voxel8 Gen3C2 Printer
+#define BOARD_VOXEL8_GEN3C      802  // Voxel8 Gen3C Printer
+#define BOARD_VOXEL8_GEN3C2     803  // Voxel8 Gen3C2 Printer
 
 #define BOARD_99                99   // This is in pins.h but...?
 


### PR DESCRIPTION
_**THIS HAS NOT BEEN TESTED ON A PRINTER YET**_

POSSIBLE CHANGES NEEDED IN PINS FILES

The purpose of this PR is to remove the need to maintain a Gen 3C branch. The only reason that branch currently exists is to change the x homing direction.

**Changes**
- Define GEN3C and GEN3C2 boards in boards.h
- Conditionally define homing directions in configuration.h, depending on what `MOTHERBOARD` is defined as.

@jminardi @kdumontnu @kevingelion 
