### PR TITLE
Add M220 verbose output

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4946,7 +4946,16 @@ inline void gcode_M211() {
  * M220: Set speed percentage factor, aka "Feed Rate" (M220 S95)
  */
 inline void gcode_M220() {
-  if (code_seen('S')) feedrate_multiplier = code_value();
+  // Set feedrate multiplier
+  if (code_seen('S')) {
+    feedrate_multiplier = code_value();
+  }
+  // Display feedrate multiplier
+  else if (code_seen('V') || code_seen('v')) {
+    SERIAL_PROTOCOLPGM("Feedrate multiplier: ");
+    SERIAL_PROTOCOL(feedrate_multiplier);
+    SERIAL_EOL;
+  }
 }
 
 /**

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4951,7 +4951,7 @@ inline void gcode_M220() {
     feedrate_multiplier = code_value();
   }
   // Display feedrate multiplier
-  else if (code_seen('V') || code_seen('v')) {
+  else {
     SERIAL_PROTOCOLPGM("Feedrate multiplier: ");
     SERIAL_PROTOCOL(feedrate_multiplier);
     SERIAL_EOL;

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4953,8 +4953,7 @@ inline void gcode_M220() {
   // Display feedrate multiplier
   else {
     SERIAL_PROTOCOLPGM("Feedrate multiplier: ");
-    SERIAL_PROTOCOL(feedrate_multiplier);
-    SERIAL_EOL;
+    SERIAL_PROTOCOLLN(feedrate_multiplier);
   }
 }
 


### PR DESCRIPTION
@pizzyflavin @dreammaker @kdumontnu @jminardi 

Display `feedrate_multiplier` (similar to `M236 v` verbose output)

I used a number of M220's over the last couple days and found myself forgetting what I had it set to, making prints somewhat difficult to reproduce... this will allow us to easily check this value from within OctoPrint