### PR TITLE
Add dual pneumatics support (disabled by default)

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -378,6 +378,9 @@ Here are some standard links for getting your machine calibrated:
 // Define this if you are using the electro-pneumatic regulator
 #define E_REGULATOR
 
+// Define this if you are using dual pneumatics
+//#define DUAL_PNEUMATICS
+
 #if ENABLED(E_REGULATOR)
  // Set E-regulator Sensor Type HERE:
  // ---------------------------------

--- a/Marlin/pins_VOXEL8_GEN3C2.h
+++ b/Marlin/pins_VOXEL8_GEN3C2.h
@@ -88,14 +88,21 @@ DIGITAL POTENTIOMETER PINS
 /*************************
 	     FFF PINS
 *************************/
-
-#define HEATER_0_PIN            CART0_SIG0_PIN
+#if ENABLED(DUAL_PNEUMATICS)
+  #define HEATER_0_PIN          2
+#else
+  #define HEATER_0_PIN          CART0_SIG0_PIN
+#endif
 #define HEATER_1_PIN            -1 // Set to CART1_SIG0_PIN to use FFF in CART1
 
 /*************************
   TEMPERATURE SENSE PINS
 *************************/
-#define TEMP_0_PIN              6   // A6 Input Cart0 Therm
+#if ENABLED(DUAL_PNEUMATICS)
+  #define TEMP_0_PIN            -1
+#else
+  #define TEMP_0_PIN            6   // A6 Input Cart0 Therm
+#endif
 #define TEMP_1_PIN              1   // A1 Input Cart1 Therm
 #define TEMP_2_PIN              -1
 
@@ -113,8 +120,12 @@ DIGITAL POTENTIOMETER PINS
     SOLENOID PINS
 *************************/
 #if ENABLED(PNEUMATICS)
-  #define SOL0_PIN                -1 // Set to CART0_SIG0_PIN for pneumatics in CART0
-  #define SOL1_PIN                CART1_SIG0_PIN
+  #if ENABLED(DUAL_PNEUMATICS)
+    #define SOL0_PIN            5
+  #else
+    #define SOL0_PIN            -1 // Set to CART0_SIG0_PIN for pneumatics in CART0
+  #endif
+  #define SOL1_PIN              CART1_SIG0_PIN
 #endif
 
 


### PR DESCRIPTION
@jminardi @pizzyflavin @kdumontnu @danthompson41 

Dual pneumatics support has been dangling at `62becf` on the `kd/refactor-UV_Command` branch for awhile now and I'd like to pull it into master from its own branch for two reasons:

1. Updating firmware via Octoprint would be nice... having this workaround in master allows us to simply create a new `Update Firmware (Dual Pneumatics)` system command with `sed -i 's://#define DUAL_PNEUMATICS:#define DUAL_PNEUMATICS:g' Marlin/Configuration.h` added before build.sh is executed... no branch-switching required, and dual pneumatics printers will still get important updates from the master branch

2. Scenarios have popped up where we'd like to bypass MAX_TEMP errors with the hotend cartridge absent... updating via Octoprint as described above is much easier than switching to the UV_command branch and building via USB