### PR TITLE
Build with Pneumatics Disabled

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5199,7 +5199,7 @@ inline void gcode_M226() {
   }
 #endif
  
-#if ENABLED(E_REGULATOR)
+#if (ENABLED(E_REGULATOR) && ENABLED(PNEUMATICS))
   /**
    * M236 - Send Value to ADC w/ no EEPROM write
    */
@@ -5288,7 +5288,7 @@ inline void gcode_M226() {
     }
     SERIAL_EOL;
   }
-#endif // E_REGULATOR
+#endif // E_REGULATOR && PNEUMATICS
 
 #if ENABLED(AUTO_BED_LEVELING_FEATURE) && ENABLED(EXT_ADC)
   /*
@@ -6862,7 +6862,7 @@ void process_next_command() {
           break;
       #endif // EXT_ADC
 
-      #if ENABLED(E_REGULATOR)
+      #if (ENABLED(E_REGULATOR) && ENABLED(PNEUMATICS))
           case 236: // Send value to DAC; return current output pressure if no S parameter
           gcode_M236();
           break;

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -312,16 +312,8 @@
       #endif
     #endif
 
-    #if EXTRUDERS > 1 || ENABLED(HEATERS_PARALLEL)
-      #if !HAS_HEATER_1
-        #error HEATER_1_PIN not defined for this board.
-      #endif
-    #endif
-
     #if TEMP_SENSOR_1 == 0
-      #if EXTRUDERS > 1
-        #error TEMP_SENSOR_1 is required with 2 or more EXTRUDERS.
-      #elif ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
+      #if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
         #error TEMP_SENSOR_1 is required with TEMP_SENSOR_1_AS_REDUNDANT.
       #endif
     #endif

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -785,7 +785,7 @@ void manage_heater() {
   #endif // PNEUMATICS
 
   // ELECTRO-PNEUMATIC REGULATOR CONTROL
-  #if ENABLED(E_REGULATOR)
+  #if (ENABLED(E_REGULATOR) && ENABLED(PNEUMATICS))
   if (millis() - previous_millis_regulator_value > REGULATOR_CHECK_INTERVAL) {
     
     previous_millis_regulator_value = millis();


### PR DESCRIPTION
![ekth0001](https://cloud.githubusercontent.com/assets/3892443/13935762/7edcd6d0-ef8f-11e5-9eeb-7f328b922f84.jpg)


This is a modification that addresses https://github.com/Voxel8/Marlin/issues/82, where we couldn't build without Pneumatics enabled.
