### PR TITLE
Increase Fan Duty Cycle Max

### DIFF
--- a/Marlin/Voxel8_I2C_Commands.cpp
+++ b/Marlin/Voxel8_I2C_Commands.cpp
@@ -16,10 +16,9 @@
 //===========================================================================
 
 // Defines for specific commands
-// 127 (50%) is maxy duty cycle for 12V fans
-// TODO: This is unnecessary for Gen 3D, keeping it here for the moment
-//       to ensure back compatability.
-#define MAX_FAN_DUTY  127
+// 127 (50%) is maxy duty cycle for 12V fans wired in parallel. 255 should be
+// fine for those wired in series (Gen 3D, and beyond).
+#define MAX_FAN_DUTY  255
 
 
 //===========================================================================


### PR DESCRIPTION
![fan-blowing-streamers](https://cloud.githubusercontent.com/assets/3892443/14052747/d8b79cc4-f2a2-11e5-831a-5e1582689d9e.jpg)

# Increasing Fan Duty Cycle

This allows us to increase the fan duty cycle for 3Ds and beyond, which have fans wired in series instead of parallel. This lowers the effective power they're getting, allowing us to PWM higher. There is an associated pull request for the cartridge holder firmware. That firmware should only be put on 3D printers are above