### PR TITLE
Dt/bugfix i2c timeout

### DIFF
--- a/ArduinoAddons/Arduino_1.6.x/hardware/marlin/avr/libraries/Wire/Wire.cpp
+++ b/ArduinoAddons/Arduino_1.6.x/hardware/marlin/avr/libraries/Wire/Wire.cpp
@@ -127,17 +127,17 @@ void TwoWire::beginTransmission(int address)
 }
 
 //
-//	Originally, 'endTransmission' was an f(void) function.
-//	It has been modified to take one parameter indicating
-//	whether or not a STOP should be performed on the bus.
-//	Calling endTransmission(false) allows a sketch to 
-//	perform a repeated start. 
+//  Originally, 'endTransmission' was an f(void) function.
+//  It has been modified to take one parameter indicating
+//  whether or not a STOP should be performed on the bus.
+//  Calling endTransmission(false) allows a sketch to 
+//  perform a repeated start. 
 //
-//	WARNING: Nothing in the library keeps track of whether
-//	the bus tenure has been properly ended with a STOP. It
-//	is very possible to leave the bus in a hung state if
-//	no call to endTransmission(true) is made. Some I2C
-//	devices will behave oddly if they do not see a STOP.
+//  WARNING: Nothing in the library keeps track of whether
+//  the bus tenure has been properly ended with a STOP. It
+//  is very possible to leave the bus in a hung state if
+//  no call to endTransmission(true) is made. Some I2C
+//  devices will behave oddly if they do not see a STOP.
 //
 uint8_t TwoWire::endTransmission(uint8_t sendStop)
 {
@@ -151,8 +151,8 @@ uint8_t TwoWire::endTransmission(uint8_t sendStop)
   return ret;
 }
 
-//	This provides backwards compatibility with the original
-//	definition, and expected behaviour, of endTransmission
+//  This provides backwards compatibility with the original
+//  definition, and expected behaviour, of endTransmission
 //
 uint8_t TwoWire::endTransmission(void)
 {
@@ -295,6 +295,14 @@ void TwoWire::onReceive( void (*function)(int) )
 void TwoWire::onRequest( void (*function)(void) )
 {
   user_onRequest = function;
+}
+
+uint8_t TwoWire::twi_getTimeoutFlag(void) {
+  return (twi_getTFlag());
+}
+
+void TwoWire::twi_resetTimeoutFlag(void) {
+  twi_resetTFlag();
 }
 
 // Preinstantiate Objects //////////////////////////////////////////////////////

--- a/ArduinoAddons/Arduino_1.6.x/hardware/marlin/avr/libraries/Wire/Wire.h
+++ b/ArduinoAddons/Arduino_1.6.x/hardware/marlin/avr/libraries/Wire/Wire.h
@@ -66,6 +66,8 @@ class TwoWire : public Stream
     virtual void flush(void);
     void onReceive( void (*)(int) );
     void onRequest( void (*)(void) );
+    void twi_resetTimeoutFlag(void);
+    uint8_t twi_getTimeoutFlag(void);
 
     inline size_t write(unsigned long n) { return write((uint8_t)n); }
     inline size_t write(long n) { return write((uint8_t)n); }

--- a/ArduinoAddons/Arduino_1.6.x/hardware/marlin/avr/libraries/Wire/utility/twi.c
+++ b/ArduinoAddons/Arduino_1.6.x/hardware/marlin/avr/libraries/Wire/utility/twi.c
@@ -27,6 +27,10 @@
 #include <compat/twi.h>
 #include "Arduino.h" // for digitalWrite
 
+//===========================================================================
+//=============================== Definitions ===============================
+//===========================================================================
+
 #ifndef cbi
 #define cbi(sfr, bit) (_SFR_BYTE(sfr) &= ~_BV(bit))
 #endif
@@ -38,10 +42,15 @@
 #include "pins_arduino.h"
 #include "twi.h"
 
+//===========================================================================
+//============================ Private Variables ============================
+//===========================================================================
+
+
 static volatile uint8_t twi_state;
 static volatile uint8_t twi_slarw;
-static volatile uint8_t twi_sendStop;			// should the transaction end with a stop
-static volatile uint8_t twi_inRepStart;			// in the middle of a repeated start
+static volatile uint8_t twi_sendStop;   // should the transaction end with a stop
+static volatile uint8_t twi_inRepStart; // in the middle of a repeated start
 
 static void (*twi_onSlaveTransmit)(void);
 static void (*twi_onSlaveReceive)(uint8_t*, int);
@@ -56,10 +65,21 @@ static volatile uint8_t twi_txBufferLength;
 
 static uint8_t twi_rxBuffer[TWI_BUFFER_LENGTH];
 static volatile uint8_t twi_rxBufferIndex;
-
 static volatile uint8_t twi_error;
 
-uint8_t twi_tout(uint8_t ini);
+static volatile uint32_t twi_toutc;
+static volatile uint8_t twi_timeout_flag = 0;
+
+//===========================================================================
+//======================= Private Function Prototypes =======================
+//===========================================================================
+
+static uint8_t twi_tout(uint8_t ini);
+
+//===========================================================================
+//============================ Public Functions =============================
+//===========================================================================
+
 /* 
  * Function twi_init
  * Desc     readys twi pins and sets twi bitrate
@@ -74,7 +94,7 @@ void twi_init(void)
   
   // initialize state
   twi_state = TWI_READY;
-  twi_sendStop = true;		// default value
+  twi_sendStop = true;    // default value
   twi_inRepStart = false;
   
   // activate internal pullups for twi.
@@ -157,9 +177,9 @@ uint8_t twi_readFrom(uint8_t address, uint8_t* data, uint8_t length, uint8_t sen
     // since the ISR is ASYNC, and we could get confused if we hit the ISR before cleaning
     // up. Also, don't enable the START interrupt. There may be one pending from the 
     // repeated start that we sent outselves, and that would really confuse things.
-    twi_inRepStart = false;			// remember, we're dealing with an ASYNC ISR
+    twi_inRepStart = false;     // remember, we're dealing with an ASYNC ISR
     TWDR = twi_slarw;
-    TWCR = _BV(TWINT) | _BV(TWEA) | _BV(TWEN) | _BV(TWIE);	// enable INTs, but not START
+    TWCR = _BV(TWINT) | _BV(TWEA) | _BV(TWEN) | _BV(TWIE);  // enable INTs, but not START
   }
   else
     // send start condition
@@ -179,7 +199,7 @@ uint8_t twi_readFrom(uint8_t address, uint8_t* data, uint8_t length, uint8_t sen
   for(i = 0; i < length; ++i){
     data[i] = twi_masterBuffer[i];
   }
-	
+  
   return length;
 }
 
@@ -241,13 +261,13 @@ uint8_t twi_writeTo(uint8_t address, uint8_t* data, uint8_t length, uint8_t wait
     // since the ISR is ASYNC, and we could get confused if we hit the ISR before cleaning
     // up. Also, don't enable the START interrupt. There may be one pending from the 
     // repeated start that we sent outselves, and that would really confuse things.
-    twi_inRepStart = false;			// remember, we're dealing with an ASYNC ISR
-    TWDR = twi_slarw;				
-    TWCR = _BV(TWINT) | _BV(TWEA) | _BV(TWEN) | _BV(TWIE);	// enable INTs, but not START
+    twi_inRepStart = false;     // remember, we're dealing with an ASYNC ISR
+    TWDR = twi_slarw;       
+    TWCR = _BV(TWINT) | _BV(TWEA) | _BV(TWEN) | _BV(TWIE);  // enable INTs, but not START
   }
   else
     // send start condition
-    TWCR = _BV(TWINT) | _BV(TWEA) | _BV(TWEN) | _BV(TWIE) | _BV(TWSTA);	// enable INTs
+    TWCR = _BV(TWINT) | _BV(TWEA) | _BV(TWEN) | _BV(TWIE) | _BV(TWSTA); // enable INTs
 
   // wait for write operation to complete
   twi_tout(1);
@@ -257,13 +277,13 @@ uint8_t twi_writeTo(uint8_t address, uint8_t* data, uint8_t length, uint8_t wait
   }
   
   if (twi_error == 0xFF)
-    return 0;	// success
+    return 0; // success
   else if (twi_error == TW_MT_SLA_NACK)
-    return 2;	// error: address send, nack received
+    return 2; // error: address send, nack received
   else if (twi_error == TW_MT_DATA_NACK)
-    return 3;	// error: data send, nack received
+    return 3; // error: data send, nack received
   else
-    return 4;	// other twi error
+    return 4; // other twi error
 }
 
 /* 
@@ -333,7 +353,7 @@ void twi_reply(uint8_t ack)
   if(ack){
     TWCR = _BV(TWEN) | _BV(TWIE) | _BV(TWINT) | _BV(TWEA);
   }else{
-	  TWCR = _BV(TWEN) | _BV(TWIE) | _BV(TWINT);
+    TWCR = _BV(TWEN) | _BV(TWIE) | _BV(TWINT);
   }
 }
 
@@ -375,18 +395,39 @@ void twi_releaseBus(void)
   twi_state = TWI_READY;
 }
 
-//Nirea. Time Out
-static volatile uint32_t twi_toutc;
-uint8_t twi_tout(uint8_t ini)
+uint8_t twi_getTFlag(void) {
+  return twi_timeout_flag;
+  //return 1;
+}
+
+void twi_resetTFlag(void) {
+  twi_timeout_flag = 0;
+}
+//===========================================================================
+//============================ Private Functions ============================
+//===========================================================================
+
+/* 
+ * Function twi_tout
+ * Desc     Time out for I2c communication 
+ * Input    ini - initialize with != 0
+ * Output   returns 1 if tripped.
+ */
+static uint8_t twi_tout(uint8_t ini)
 {
   if (ini) twi_toutc=0; else twi_toutc++; 
   if (twi_toutc>=10000UL) {
     twi_toutc=0;
+    twi_timeout_flag = 1;
     twi_init();
     return 1;
   }
   return 0;  
 }
+
+//===========================================================================
+//=========================== Interrupt Handlers ============================
+//===========================================================================
 
 ISR(TWI_vect)
 {
@@ -408,16 +449,16 @@ ISR(TWI_vect)
         TWDR = twi_masterBuffer[twi_masterBufferIndex++];
         twi_reply(1);
       }else{
-	if (twi_sendStop)
+  if (twi_sendStop)
           twi_stop();
-	else {
-	  twi_inRepStart = true;	// we're gonna send the START
-	  // don't enable the interrupt. We'll generate the start, but we 
-	  // avoid handling the interrupt until we're in the next transaction,
-	  // at the point where we would normally issue the start.
-	  TWCR = _BV(TWINT) | _BV(TWSTA)| _BV(TWEN) ;
-	  twi_state = TWI_READY;
-	}
+  else {
+    twi_inRepStart = true;  // we're gonna send the START
+    // don't enable the interrupt. We'll generate the start, but we 
+    // avoid handling the interrupt until we're in the next transaction,
+    // at the point where we would normally issue the start.
+    TWCR = _BV(TWINT) | _BV(TWSTA)| _BV(TWEN) ;
+    twi_state = TWI_READY;
+  }
       }
       break;
     case TW_MT_SLA_NACK:  // address sent, nack received
@@ -448,17 +489,17 @@ ISR(TWI_vect)
     case TW_MR_DATA_NACK: // data received, nack sent
       // put final byte into buffer
       twi_masterBuffer[twi_masterBufferIndex++] = TWDR;
-	if (twi_sendStop)
+  if (twi_sendStop)
           twi_stop();
-	else {
-	  twi_inRepStart = true;	// we're gonna send the START
-	  // don't enable the interrupt. We'll generate the start, but we 
-	  // avoid handling the interrupt until we're in the next transaction,
-	  // at the point where we would normally issue the start.
-	  TWCR = _BV(TWINT) | _BV(TWSTA)| _BV(TWEN) ;
-	  twi_state = TWI_READY;
-	}    
-	break;
+  else {
+    twi_inRepStart = true;  // we're gonna send the START
+    // don't enable the interrupt. We'll generate the start, but we 
+    // avoid handling the interrupt until we're in the next transaction,
+    // at the point where we would normally issue the start.
+    TWCR = _BV(TWINT) | _BV(TWSTA)| _BV(TWEN) ;
+    twi_state = TWI_READY;
+  }    
+  break;
     case TW_MR_SLA_NACK: // address sent, nack received
       twi_stop();
       break;

--- a/ArduinoAddons/Arduino_1.6.x/hardware/marlin/avr/libraries/Wire/utility/twi.h
+++ b/ArduinoAddons/Arduino_1.6.x/hardware/marlin/avr/libraries/Wire/utility/twi.h
@@ -48,6 +48,8 @@
   void twi_reply(uint8_t);
   void twi_stop(void);
   void twi_releaseBus(void);
+  void twi_resetTFlag(void);
+  uint8_t twi_getTFlag(void);
 
 #endif
 

--- a/Marlin/Voxel8_I2C_Commands.cpp
+++ b/Marlin/Voxel8_I2C_Commands.cpp
@@ -273,8 +273,18 @@ void requestAndPrintPacket(uint8_t I2C_target_address,
                            uint8_t bytes) {
     // Read from cartridge and report
     Wire.requestFrom(I2C_target_address, bytes);
-    while (Wire.available()) {
+    if (!Wire.available()) {
+      SERIAL_PROTOCOL(" No Packet Available ");
+    }
+    else {
+      while (Wire.available()) {
         SERIAL_PROTOCOL(Wire.read());
+        if (Wire.twi_getTimeoutFlag()) {
+          SERIAL_PROTOCOL(" I2C Timeout occurred ");
+          SERIAL_PROTOCOL(Wire.twi_getTimeoutFlag());
+          Wire.twi_resetTimeoutFlag();
+        }
+      }
     }
     SERIAL_EOL;
 }


### PR DESCRIPTION
I2C causes the system to hang unless a timeout is implemented. This fixes it and adds some reporting on the marlin side

NOTE:

Changing these arduino files (wire and twi) won't actually cause your upload to change, we need to put these copies in the arduino library directory. In the pursuit of making this less awful, we're moving to a hex file code distribution system
