### PR TITLE
Update Y_MAX_POS to 187 to allow printing in full bed volume

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -520,7 +520,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define Y_MIN_POS 0
 #define Z_MIN_POS 0
 #define X_MAX_POS 188
-#define Y_MAX_POS 178
+#define Y_MAX_POS 187
 #define Z_MAX_POS 105
 
 //===========================================================================

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -520,7 +520,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define Y_MIN_POS 0
 #define Z_MIN_POS 0
 #define X_MAX_POS 188
-#define Y_MAX_POS 187
+#define Y_MAX_POS 188
 #define Z_MAX_POS 105
 
 //===========================================================================


### PR DESCRIPTION
We had previously set this value to 178 in e1526fe0 to prevent crashing
the cartridge holder into a closed lid, but we've made some design
changes since then that make that limitation unnecessary. I tried 188
to match the X_MAX_POS value but 187 actually lines up on a tape square
pretty perfectly (188 is good for X_MAX though).

(See Voxel8/DevKit-Issues#42)