### PR TITLE
Bugfix - Heated bed present signal is not within specs

### DIFF
--- a/Marlin/HeatedBed.cpp
+++ b/Marlin/HeatedBed.cpp
@@ -37,7 +37,7 @@ void heatedBedRemovedError(void);
 bool HeatedBed__PresentCheck(void) {
 	#if ENABLED(HEATED_BED_PRESENT_CHECK)
 		bool returnValue = false;
-		if (READ(BED_AVAIL_PIN) == HIGH) {
+		if (current_temperature_bed > BED_MINTEMP) {
 			returnValue = true;
 		}
 		else {


### PR DESCRIPTION
 Electrically, the heated bed present signal is sketchy so this is more consistent. Now triggering off of the temperature read from the bed instead of the key signal