### PR TITLE
Dt/enhancement disable heated bed check mcode

### DIFF
--- a/Marlin/HeatedBed.cpp
+++ b/Marlin/HeatedBed.cpp
@@ -36,7 +36,7 @@ void heatedBedRemovedError(void);
  * @returns    Returns true if the heated bed is present
  */
 bool HeatedBed__PresentCheck(void) {
-	if (bedRemovalCheckEnabled && HEATED_BED_PRESENT_CHECK) {
+	if (bedRemovalCheckEnabled && ENABLED(HEATED_BED_PRESENT_CHECK)) {
 		bool returnValue = false;
 		if (READ(BED_AVAIL_PIN) == HIGH) {
 			returnValue = true;
@@ -53,17 +53,17 @@ bool HeatedBed__PresentCheck(void) {
 
 void HeatedBed__SetPresentCheck(bool value) {
 	if (value == true) {
-		SERIAL_PROTOCOL("Heated Bed Check Enabled")
-		SERIAL_EOL
-		bedRemovalCheckEnabled = 1
+		SERIAL_PROTOCOL("Heated Bed Check Enabled");
+		SERIAL_EOL;
+		bedRemovalCheckEnabled = 1;
 	}
 	else if (value == false) {
-		SERIAL_PROTOCOL("Heated Bed Check Disabled")
+		SERIAL_PROTOCOL("Heated Bed Check Disabled");
 		SERIAL_EOL;
-		bedRemovalCheckEnabled = 0
+		bedRemovalCheckEnabled = 0;
 	}
 	else {
-		SERIAL_PROTOCOL("Invalid value for Heated Bed Check Set")
+		SERIAL_PROTOCOL("Invalid value for Heated Bed Check Set");
 		SERIAL_EOL;
 		return;
 	}

--- a/Marlin/HeatedBed.cpp
+++ b/Marlin/HeatedBed.cpp
@@ -20,12 +20,13 @@
 //============================ Private Variables ============================
 //===========================================================================
 
+static bool bedRemovalCheckEnabled = 1;
+
 //===========================================================================
 //====================== Private Functions Prototypes =======================
 //===========================================================================
 
 void heatedBedRemovedError(void);
-
 //===========================================================================
 //============================ Public Functions =============================
 //===========================================================================
@@ -35,7 +36,7 @@ void heatedBedRemovedError(void);
  * @returns    Returns true if the heated bed is present
  */
 bool HeatedBed__PresentCheck(void) {
-	#if ENABLED(HEATED_BED_PRESENT_CHECK)
+	if (bedRemovalCheckEnabled && HEATED_BED_PRESENT_CHECK) {
 		bool returnValue = false;
 		if (READ(BED_AVAIL_PIN) == HIGH) {
 			returnValue = true;
@@ -44,9 +45,29 @@ bool HeatedBed__PresentCheck(void) {
 			heatedBedRemovedError();
 		}
 		return returnValue;
-	#else
+	}
+	else {
 		return true;
-	#endif
+	}
+}
+
+void HeatedBed__SetPresentCheck(bool value) {
+	if (value == true) {
+		SERIAL_PROTOCOL("Heated Bed Check Enabled")
+		SERIAL_EOL
+		bedRemovalCheckEnabled = 1
+	}
+	else if (value == false) {
+		SERIAL_PROTOCOL("Heated Bed Check Disabled")
+		SERIAL_EOL;
+		bedRemovalCheckEnabled = 0
+	}
+	else {
+		SERIAL_PROTOCOL("Invalid value for Heated Bed Check Set")
+		SERIAL_EOL;
+		return;
+	}
+	bedRemovalCheckEnabled = value;
 }
 
 //===========================================================================

--- a/Marlin/HeatedBed.h
+++ b/Marlin/HeatedBed.h
@@ -19,5 +19,6 @@
  * @returns    Returns true if the heated bed is present
  */
 bool HeatedBed__PresentCheck(void);
+void HeatedBed__SetPresentCheck(bool value);
 
 #endif  // MARLIN_HEATED_BED_H_

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4978,6 +4978,33 @@ inline void gcode_M245() {
 
 }
 
+/*
+* M246 - Enable / Disable Heated Bed Check
+*   E - 0 - 1   1 = Enable, 0 = Disable
+*/
+inline void gcode_M246() {
+  // Used to see if we've been given arguments, and to warn you through the
+  // serial port if they're not seen.
+  bool hasE;
+
+  // Desired address for peripheral device
+  if (hasC = code_seen('E')) {
+    switch(int(code_value())) {
+      case 0:
+        HeatedBed__SetPresentCheck(false)
+        break;
+      case 1:
+        HeatedBed__SetPresentCheck(true)
+        break;
+    }
+  }
+  
+  if (!hasC){
+    SERIAL_ECHOLNPGM("Enable (E1) or Disable (E0) not given");
+    return;
+  }
+}
+
 #if HAS_SERVOS
 
   /**
@@ -6458,7 +6485,11 @@ void process_next_command() {
       case 245: // M245 - I2C Diagnostics Readout C: Cartridge
         gcode_M245();
         break;
-        
+      
+      case 246: // M246 - Enable / Disable Heated Bed Check
+        gcode_M246();
+        break;
+
       #if HAS_SERVOS
         case 280: // M280 - set servo position absolute. P: servo index, S: angle or microseconds
           gcode_M280();

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4988,18 +4988,18 @@ inline void gcode_M246() {
   bool hasE;
 
   // Desired address for peripheral device
-  if (hasC = code_seen('E')) {
+  if (hasE = code_seen('E')) {
     switch(int(code_value())) {
       case 0:
-        HeatedBed__SetPresentCheck(false)
+        HeatedBed__SetPresentCheck(false);
         break;
       case 1:
-        HeatedBed__SetPresentCheck(true)
+        HeatedBed__SetPresentCheck(true);
         break;
     }
   }
   
-  if (!hasC){
+  if (!hasE){
     SERIAL_ECHOLNPGM("Enable (E1) or Disable (E0) not given");
     return;
   }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4979,10 +4979,10 @@ inline void gcode_M245() {
 }
 
 /*
-* M246 - Enable / Disable Heated Bed Check
+* M249 - Enable / Disable Heated Bed Check
 *   E - 0 - 1   1 = Enable, 0 = Disable
 */
-inline void gcode_M246() {
+inline void gcode_M249() {
   // Used to see if we've been given arguments, and to warn you through the
   // serial port if they're not seen.
   bool hasE;
@@ -6486,8 +6486,8 @@ void process_next_command() {
         gcode_M245();
         break;
       
-      case 246: // M246 - Enable / Disable Heated Bed Check
-        gcode_M246();
+      case 249: // M249 - Enable / Disable Heated Bed Check
+        gcode_M249();
         break;
 
       #if HAS_SERVOS


### PR DESCRIPTION
Allows the heated bed present check before homing to be enabled or disabled using M246. 

M249 E1 = Enabled
M249 E0 = Disabled