### PR TITLE
Heartbeat over I2C to check cartridge status

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -522,7 +522,10 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define X_MAX_POS 150
 #define Y_MAX_POS 188
 #define Z_MAX_POS 105
-
+#define X_BED_MAX 150
+#define Y_BED_MAX 150
+#define X_BED_CENTER (X_BED_MAX / 2)
+#define Y_BED_CENTER (Y_BED_MAX / 2) 
 //===========================================================================
 //========================= Filament Runout Sensor ==========================
 //===========================================================================
@@ -647,8 +650,8 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
       #define Z_SAFE_HOMING_X_POINT (100 + X_MIN_POS + X_PROBE_OFFSET_FROM_EXTRUDER)    // X point for Z homing when homing all axis (G28)
       #define Z_SAFE_HOMING_Y_POINT (150 + Y_MIN_POS + Y_PROBE_OFFSET_FROM_EXTRUDER)    // Y point for Z homing when homing all axis (G28)
     #else
-      #define Z_SAFE_HOMING_X_POINT (113.6 + X_MIN_POS)    // X point for Z homing when homing all axis (G28)
-      #define Z_SAFE_HOMING_Y_POINT (66.0 + Y_MIN_POS)     // Y point for Z homing when homing all axis (G28)
+      #define Z_SAFE_HOMING_X_POINT (X_BED_CENTER)    // X point for Z homing when homing all axis (G28)
+      #define Z_SAFE_HOMING_Y_POINT (Y_BED_CENTER)    // Y point for Z homing when homing all axis (G28)
     #endif
   #endif
 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -49,7 +49,7 @@ Here are some standard links for getting your machine calibrated:
 // User-specified version info of this build to display in [Pronterface, etc] terminal window during
 // startup. Implementation of an idea by Prof Braino to inform user that any changes made to this
 // build by the user have been successfully uploaded into firmware.
-#define STRING_CONFIG_H_AUTHOR "ricky@voxel8.co" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "Voxel8" // Who made the changes.
 #define SHOW_BOOTSCREEN
 #define STRING_SPLASH_LINE1 SHORT_BUILD_VERSION // will be shown during bootup in line 1
 //#define STRING_SPLASH_LINE2 STRING_DISTRIBUTION_DATE // will be shown during bootup in line 2

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -303,7 +303,7 @@ Note the A4982 is set to be limited to 2A. This means the adjustable voltage ran
 Wv, to be entered into firmware or directly over SPI.
 Wv = (VRef / 1.66) * 255
 */
-#define DIGIPOT_MOTOR_CURRENT {135,135,191,60,135} // Values 0-255 (RAMBO 90 = ~0.75A, 185 = ~1.5A)
+#define DIGIPOT_MOTOR_CURRENT {135,135,191,75,135} // Values 0-255 (RAMBO 90 = ~0.75A, 185 = ~1.5A)
 
 // uncomment to enable an I2C based DIGIPOT like on the Azteeg X3 Pro
 //#define DIGIPOT_I2C

--- a/Marlin/HeatedBed.cpp
+++ b/Marlin/HeatedBed.cpp
@@ -20,12 +20,13 @@
 //============================ Private Variables ============================
 //===========================================================================
 
+static bool bedRemovalCheckEnabled = 1;
+
 //===========================================================================
 //====================== Private Functions Prototypes =======================
 //===========================================================================
 
 void heatedBedRemovedError(void);
-
 //===========================================================================
 //============================ Public Functions =============================
 //===========================================================================
@@ -35,7 +36,7 @@ void heatedBedRemovedError(void);
  * @returns    Returns true if the heated bed is present
  */
 bool HeatedBed__PresentCheck(void) {
-	#if ENABLED(HEATED_BED_PRESENT_CHECK)
+	if (bedRemovalCheckEnabled && ENABLED(HEATED_BED_PRESENT_CHECK)) {
 		bool returnValue = false;
 		if (current_temperature_bed > BED_MINTEMP) {
 			returnValue = true;
@@ -44,9 +45,29 @@ bool HeatedBed__PresentCheck(void) {
 			heatedBedRemovedError();
 		}
 		return returnValue;
-	#else
+	}
+	else {
 		return true;
-	#endif
+	}
+}
+
+void HeatedBed__SetPresentCheck(bool value) {
+	if (value == true) {
+		SERIAL_PROTOCOL("Heated Bed Check Enabled");
+		SERIAL_EOL;
+		bedRemovalCheckEnabled = 1;
+	}
+	else if (value == false) {
+		SERIAL_PROTOCOL("Heated Bed Check Disabled");
+		SERIAL_EOL;
+		bedRemovalCheckEnabled = 0;
+	}
+	else {
+		SERIAL_PROTOCOL("Invalid value for Heated Bed Check Set");
+		SERIAL_EOL;
+		return;
+	}
+	bedRemovalCheckEnabled = value;
 }
 
 //===========================================================================

--- a/Marlin/HeatedBed.h
+++ b/Marlin/HeatedBed.h
@@ -19,5 +19,6 @@
  * @returns    Returns true if the heated bed is present
  */
 bool HeatedBed__PresentCheck(void);
+void HeatedBed__SetPresentCheck(bool value);
 
 #endif  // MARLIN_HEATED_BED_H_

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4978,6 +4978,33 @@ inline void gcode_M245() {
 
 }
 
+/*
+* M249 - Enable / Disable Heated Bed Check
+*   E - 0 - 1   1 = Enable, 0 = Disable
+*/
+inline void gcode_M249() {
+  // Used to see if we've been given arguments, and to warn you through the
+  // serial port if they're not seen.
+  bool hasE;
+
+  // Desired address for peripheral device
+  if (hasE = code_seen('E')) {
+    switch(int(code_value())) {
+      case 0:
+        HeatedBed__SetPresentCheck(false);
+        break;
+      case 1:
+        HeatedBed__SetPresentCheck(true);
+        break;
+    }
+  }
+  
+  if (!hasE){
+    SERIAL_ECHOLNPGM("Enable (E1) or Disable (E0) not given");
+    return;
+  }
+}
+
 #if HAS_SERVOS
 
   /**
@@ -6458,7 +6485,11 @@ void process_next_command() {
       case 245: // M245 - I2C Diagnostics Readout C: Cartridge
         gcode_M245();
         break;
-        
+      
+      case 249: // M249 - Enable / Disable Heated Bed Check
+        gcode_M249();
+        break;
+
       #if HAS_SERVOS
         case 280: // M280 - set servo position absolute. P: servo index, S: angle or microseconds
           gcode_M280();

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -240,8 +240,11 @@
  *
  * ************ Custom codes - This can change to suit future G-code regulations
  * M100 - Watch Free Memory (For Debugging Only)
+
+ * M850 - Display firmware version
+
  * M851 - Set Z probe's Z offset (mm above extruder -- The value will always be negative)
-                                     *
+
  * M852 - Automaticaly adjust the Z probe's Z offset so that the current position is set to 0.
 
 
@@ -5847,6 +5850,27 @@ inline void gcode_M503() {
 
 #endif // DUAL_X_CARRIAGE
 
+/**
+* M850 - Display firmware version
+*/
+
+inline void gcode_M850() {
+  SERIAL_ECHOPGM("Version ");
+  SERIAL_ECHOLNPGM(DETAILED_BUILD_VERSION);
+
+  #ifdef STRING_DISTRIBUTION_DATE
+    #ifdef STRING_CONFIG_H_AUTHOR
+      SERIAL_ECHO_START;
+      SERIAL_ECHOPGM(MSG_CONFIGURATION_VER);
+      SERIAL_ECHOPGM(STRING_DISTRIBUTION_DATE);
+      SERIAL_ECHOPGM(MSG_AUTHOR);
+      SERIAL_ECHOLNPGM(STRING_CONFIG_H_AUTHOR);
+      SERIAL_ECHOPGM("Compiled: ");
+      SERIAL_ECHOLNPGM(__DATE__);
+    #endif // STRING_CONFIG_H_AUTHOR
+  #endif // STRING_DISTRIBUTION_DATE
+}
+
 /*
 * M852 - Set new bed zero point. This mcode modifies the zprobe offset to make
 *        the current position 0 after homing. The new offset is stored in
@@ -6705,6 +6729,10 @@ void process_next_command() {
           break;
 
       #endif // HAS_MICROSTEPS
+
+      case 850:
+        gcode_M850(); // M850 - Display firmware version
+        break;
 
       case 852:
         gcode_M852(); // M852 - Set new bed zero point

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3614,15 +3614,15 @@ inline void gcode_M105() {
   #endif
 
   // Get error codes from present cartridges
-  // if (CartridgePresent(0)) {
-  //   SERIAL_PROTOCOL(" C0: ");
-  //   I2C__GetErrorCode(CART0_ADDR);
-  // }
+  if (CartridgePresent(0)) {
+    SERIAL_PROTOCOL(" C0: ");
+    I2C__GetErrorCode(CART0_ADDR);
+  }
 
-  // if (CartridgePresent(1)) {
-  //   SERIAL_PROTOCOL(" C1: ");
-  //   I2C__GetErrorCode(CART1_ADDR);
-  // }
+  if (CartridgePresent(1)) {
+    SERIAL_PROTOCOL(" C1: ");
+    I2C__GetErrorCode(CART1_ADDR);
+  }
 
   SERIAL_EOL;
 }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -192,6 +192,8 @@
  * M239 - Homing and bed leveling combination
  * M240 - Trigger a camera to take a photograph
  * M241 - Dwell for a given amount of time in milliseconds (500 by default)
+ * M242 - General I2C Message Interface A<address> P<command> S<value>
+ * M247 - UV S<value> 0/255 to enable/disable 
  * M250 - Set LCD contrast C<contrast value> (value 0..63)
  * M280 - Set servo position absolute. P: servo index, S: angle or microseconds
  * M300 - Play beep sound S<frequency Hz> P<duration ms>
@@ -4978,6 +4980,28 @@ inline void gcode_M245() {
 
 }
 
+/**
+* M247 - UV LED Enable/Disable
+*   S - 0 - 255 value to send
+*/
+inline void gcode_M247() {
+  int verbose_level = code_seen('V') || code_seen('v') ? code_value_short() : 0;
+  if (verbose_level < 0 || verbose_level > 4) {
+    SERIAL_ECHOLNPGM("?(V)erbose Level is implausible (0-4).");
+    return;
+  }
+
+  uint8_t i2c_data;
+
+  // Desired value given
+  if (code_seen('S')) {
+    i2c_data = code_value();
+  }
+  // TODO: add check whether S param is in bounds.
+
+  I2C__ToggleUV(i2c_data);
+}
+
 /*
 * M249 - Enable / Disable Heated Bed Check
 *   E - 0 - 1   1 = Enable, 0 = Disable
@@ -6522,6 +6546,10 @@ void process_next_command() {
 
       case 241: // M241 - Dwell for a given amount of time in milliseconds (500 by default)
         gcode_M241();
+        break;
+        
+      case 247: // UV LED Enable/Disable
+        gcode_M247();
         break;
 
       #if ENABLED(HAS_LCD_CONTRAST)

--- a/Marlin/Voxel8_I2C_Commands.cpp
+++ b/Marlin/Voxel8_I2C_Commands.cpp
@@ -164,6 +164,7 @@ void I2C__EEPROMWrite(uint8_t cartridge,
 
     // Read from cartridge and report
     requestAndPrintPacket(cartridge, 1);
+    SERIAL_EOL;
 }
 
 /**
@@ -182,6 +183,7 @@ void I2C__EEPROMRead(uint8_t cartridge,
 
     // Read from cartridge and report
     requestAndPrintPacket(cartridge, 1);
+    SERIAL_EOL;
 }
 
 /**
@@ -198,7 +200,7 @@ void I2C__GetSerial(uint8_t cartridge) {
 
     // Read from cartridge and report
     requestAndPrintSerial(cartridge);
-    //requestAndPrintPacket(cartridge,4);
+    SERIAL_EOL;
 }
 
 /**
@@ -216,6 +218,7 @@ void I2C__GetProgrammerStation(uint8_t cartridge) {
 
     // Read from cartridge and report
     requestAndPrintPacket(cartridge, 1);
+    SERIAL_EOL;
 }
 
 /**
@@ -232,6 +235,7 @@ void I2C__GetCartridgeType(uint8_t cartridge) {
 
     // Read from cartridge and report
     requestAndPrintPacket(cartridge, 1);
+    SERIAL_EOL;
 }
 
 /**
@@ -248,6 +252,7 @@ void I2C__GetSize(uint8_t cartridge) {
 
     // Read from cartridge and report
     requestAndPrintPacket(cartridge, 1);
+    SERIAL_EOL;
 }
 
 /**
@@ -264,6 +269,7 @@ void I2C__GetMaterial(uint8_t cartridge) {
 
     // Read from cartridge and report
     requestAndPrintPacket(cartridge, 1);
+    SERIAL_EOL;
 }
 
 /**
@@ -290,6 +296,7 @@ void I2C__GetFirmwareVersion(uint8_t cartridge) {
     SERIAL_PROTOCOL("Cartridge Firmware Version = ");
     // Read from cartridge and report
     requestAndPrintPacket(cartridge, 1);
+    SERIAL_EOL;
 }
 
 //===========================================================================
@@ -322,7 +329,6 @@ void requestAndPrintPacket(uint8_t I2C_target_address,
     while (Wire.available()) {
         SERIAL_PROTOCOL(Wire.read());
     }
-    SERIAL_EOL;
 }
 
 void requestAndPrintSerial(uint8_t I2C_target_address) {

--- a/Marlin/Voxel8_I2C_Commands.cpp
+++ b/Marlin/Voxel8_I2C_Commands.cpp
@@ -125,6 +125,25 @@ void I2C__SetFanOff(void) {
 }
 
 /**
+ * Toggles the UV LED
+ * @parameter data                0 to disable, enabled on call otherwise
+ */
+void I2C__ToggleUV(uint8_t data) {
+
+    // Send message
+    writeThreeBytePacket(CART_HOLDER_ADDR, SET_LED_UV_0_PWM,
+                         I2C_EMPTY_ADDRESS, data);
+
+    // Send information to Octoprint
+    #if defined(DEBUG)
+      SERIAL_PROTOCOLLNPGM("Command: 'I2C Command' Sent");
+      SERIAL_PROTOCOL("data = ");
+      SERIAL_PROTOCOL((int)data);
+      SERIAL_EOL;
+    #endif // end DEBUG
+}
+
+/**
  * Writes data to a specific EEPROM address on a cartridge
  * @parameter cartridge           Address of the target (cartridge)
  * @parameter address             The EEPROM address being written to

--- a/Marlin/Voxel8_I2C_Commands.h
+++ b/Marlin/Voxel8_I2C_Commands.h
@@ -27,7 +27,7 @@
 
 // I2C Commands
 #define SET_FAN_DRIVE_0_PWM     0x01
-#define SET_LED_WHITE_0_PWM     0x02
+#define RESERVED_CMD_02         0x02
 #define SET_LED_WHITE_1_PWM     0x03
 #define SET_LED_RED_0_PWM       0x04
 #define SET_LED_UV_0_PWM        0x05

--- a/Marlin/Voxel8_I2C_Commands.h
+++ b/Marlin/Voxel8_I2C_Commands.h
@@ -67,6 +67,12 @@ void I2C__SetFanDrive0PWM(uint8_t fanSpeed);
 void I2C__SetFanOff(void);
 
 /**
+ * Toggles the UV LED
+ * @parameter data                0 to disable, enabled on call otherwise
+ */
+void I2C__ToggleUV(uint8_t data);
+
+/**
  * Writes data to a specific EEPROM address on a cartridge
  * @parameter cartridge           Address of the target (cartridge)
  * @parameter address             The EEPROM address being written to


### PR DESCRIPTION
Heartbeat for cartridges to see if they've thrown an error code. Added to the end of M105 which is called periodically.