### PR TITLE
St/feature m850 display version

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -49,7 +49,7 @@ Here are some standard links for getting your machine calibrated:
 // User-specified version info of this build to display in [Pronterface, etc] terminal window during
 // startup. Implementation of an idea by Prof Braino to inform user that any changes made to this
 // build by the user have been successfully uploaded into firmware.
-#define STRING_CONFIG_H_AUTHOR "ricky@voxel8.co" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "Voxel8" // Who made the changes.
 #define SHOW_BOOTSCREEN
 #define STRING_SPLASH_LINE1 SHORT_BUILD_VERSION // will be shown during bootup in line 1
 //#define STRING_SPLASH_LINE2 STRING_DISTRIBUTION_DATE // will be shown during bootup in line 2

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -238,8 +238,11 @@
  *
  * ************ Custom codes - This can change to suit future G-code regulations
  * M100 - Watch Free Memory (For Debugging Only)
+
+ * M850 - Display firmware version
+
  * M851 - Set Z probe's Z offset (mm above extruder -- The value will always be negative)
-                                     *
+
  * M852 - Automaticaly adjust the Z probe's Z offset so that the current position is set to 0.
 
 
@@ -5796,6 +5799,27 @@ inline void gcode_M503() {
 
 #endif // DUAL_X_CARRIAGE
 
+/**
+* M850 - Display firmware version
+*/
+
+inline void gcode_M850() {
+  SERIAL_ECHOPGM("Version ");
+  SERIAL_ECHOLNPGM(DETAILED_BUILD_VERSION);
+
+  #ifdef STRING_DISTRIBUTION_DATE
+    #ifdef STRING_CONFIG_H_AUTHOR
+      SERIAL_ECHO_START;
+      SERIAL_ECHOPGM(MSG_CONFIGURATION_VER);
+      SERIAL_ECHOPGM(STRING_DISTRIBUTION_DATE);
+      SERIAL_ECHOPGM(MSG_AUTHOR);
+      SERIAL_ECHOLNPGM(STRING_CONFIG_H_AUTHOR);
+      SERIAL_ECHOPGM("Compiled: ");
+      SERIAL_ECHOLNPGM(__DATE__);
+    #endif // STRING_CONFIG_H_AUTHOR
+  #endif // STRING_DISTRIBUTION_DATE
+}
+
 /*
 * M852 - Set new bed zero point. This mcode modifies the zprobe offset to make
 *        the current position 0 after homing. The new offset is stored in
@@ -6646,6 +6670,10 @@ void process_next_command() {
           break;
 
       #endif // HAS_MICROSTEPS
+
+      case 850:
+        gcode_M850(); // M850 - Display firmware version
+        break;
 
       case 852:
         gcode_M852(); // M852 - Set new bed zero point


### PR DESCRIPTION
This allows us to easily check a printer's installed firmware with `M850` without having to restart and wait for a full reboot.