### PR TITLE
Dt/feature heartbeat for cartridges

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3614,15 +3614,15 @@ inline void gcode_M105() {
   #endif
 
   // Get error codes from present cartridges
-  // if (CartridgePresent(0)) {
-  //   SERIAL_PROTOCOL(" C0: ");
-  //   I2C__GetErrorCode(CART0_ADDR);
-  // }
+  if (CartridgePresent(0)) {
+    SERIAL_PROTOCOL(" C0: ");
+    I2C__GetErrorCode(CART0_ADDR);
+  }
 
-  // if (CartridgePresent(1)) {
-  //   SERIAL_PROTOCOL(" C1: ");
-  //   I2C__GetErrorCode(CART1_ADDR);
-  // }
+  if (CartridgePresent(1)) {
+    SERIAL_PROTOCOL(" C1: ");
+    I2C__GetErrorCode(CART1_ADDR);
+  }
 
   SERIAL_EOL;
 }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5059,6 +5059,32 @@ inline void gcode_M249() {
   }
 }
 
+inline void gcode_M252() {
+  uint8_t i2c_address = 0xFF;
+  // Used to see if we've been given arguments, and to warn you through the
+  // serial port if they're not seen.
+  bool hasC;
+
+  // Desired address for peripheral device
+  if (hasC = code_seen('C')) {
+    switch(int(code_value())) {
+      case 0:
+        i2c_address = CART0_ADDR;
+        break;
+      case 1:
+        i2c_address = CART1_ADDR;
+        break;
+    }
+  }
+  
+  if (!hasC){
+    SERIAL_ECHOLNPGM("No cartridge address given");
+    return;
+  }
+
+  I2C__ClearError(i2c_address);
+}
+
 #if HAS_SERVOS
 
   /**
@@ -6612,6 +6638,10 @@ void process_next_command() {
           gcode_M250();
           break;
       #endif // HAS_LCD_CONTRAST
+
+      case 252:
+        gcode_M252();
+        break;
 
       #if ENABLED(PREVENT_DANGEROUS_EXTRUDE)
         case 302: // allow cold extrudes, or set the minimum extrude temperature

--- a/Marlin/Voxel8_I2C_Commands.cpp
+++ b/Marlin/Voxel8_I2C_Commands.cpp
@@ -299,6 +299,18 @@ void I2C__GetFirmwareVersion(uint8_t cartridge) {
     SERIAL_EOL;
 }
 
+/**
+ * Clear the error flag for a particular cartridge if it's set
+ * @parameter cartridge           Address of the target (cartridge)
+ */ 
+void I2C__ClearError(uint8_t cartridge) {
+    // Send message
+    writeThreeBytePacket(cartridge, CLEAR_ERROR, I2C_EMPTY_ADDRESS,
+                         I2C_EMPTY_DATA);
+    SERIAL_PROTOCOL("Cleared Error State");
+    SERIAL_EOL;
+}
+
 //===========================================================================
 //============================ Private Functions ============================
 //===========================================================================

--- a/Marlin/Voxel8_I2C_Commands.cpp
+++ b/Marlin/Voxel8_I2C_Commands.cpp
@@ -326,10 +326,21 @@ void requestAndPrintPacket(uint8_t I2C_target_address,
                            uint8_t bytes) {
     // Read from cartridge and report
     Wire.requestFrom(I2C_target_address, bytes);
-    while (Wire.available()) {
+    if (!Wire.available()) {
+      SERIAL_PROTOCOL(" No Packet Available ");
+    }
+    else {
+      while (Wire.available()) {
         SERIAL_PROTOCOL(Wire.read());
+        if (Wire.twi_getTimeoutFlag()) {
+          SERIAL_PROTOCOL(" I2C Timeout occurred ");
+          SERIAL_PROTOCOL(Wire.twi_getTimeoutFlag());
+          Wire.twi_resetTimeoutFlag();
+        }
+      }
     }
 }
+
 
 void requestAndPrintSerial(uint8_t I2C_target_address) {
     int buffer[CARTRIDGE_SERIAL_LENGTH] = {};

--- a/Marlin/Voxel8_I2C_Commands.cpp
+++ b/Marlin/Voxel8_I2C_Commands.cpp
@@ -164,6 +164,7 @@ void I2C__EEPROMWrite(uint8_t cartridge,
 
     // Read from cartridge and report
     requestAndPrintPacket(cartridge, 1);
+    SERIAL_EOL;
 }
 
 /**
@@ -182,6 +183,7 @@ void I2C__EEPROMRead(uint8_t cartridge,
 
     // Read from cartridge and report
     requestAndPrintPacket(cartridge, 1);
+    SERIAL_EOL;
 }
 
 /**
@@ -198,7 +200,7 @@ void I2C__GetSerial(uint8_t cartridge) {
 
     // Read from cartridge and report
     requestAndPrintSerial(cartridge);
-    //requestAndPrintPacket(cartridge,4);
+    SERIAL_EOL;
 }
 
 /**
@@ -216,6 +218,7 @@ void I2C__GetProgrammerStation(uint8_t cartridge) {
 
     // Read from cartridge and report
     requestAndPrintPacket(cartridge, 1);
+    SERIAL_EOL;
 }
 
 /**
@@ -232,6 +235,7 @@ void I2C__GetCartridgeType(uint8_t cartridge) {
 
     // Read from cartridge and report
     requestAndPrintPacket(cartridge, 1);
+    SERIAL_EOL;
 }
 
 /**
@@ -248,6 +252,7 @@ void I2C__GetSize(uint8_t cartridge) {
 
     // Read from cartridge and report
     requestAndPrintPacket(cartridge, 1);
+    SERIAL_EOL;
 }
 
 /**
@@ -264,6 +269,7 @@ void I2C__GetMaterial(uint8_t cartridge) {
 
     // Read from cartridge and report
     requestAndPrintPacket(cartridge, 1);
+    SERIAL_EOL;
 }
 
 /**
@@ -290,6 +296,7 @@ void I2C__GetFirmwareVersion(uint8_t cartridge) {
     SERIAL_PROTOCOL("Cartridge Firmware Version = ");
     // Read from cartridge and report
     requestAndPrintPacket(cartridge, 1);
+    SERIAL_EOL;
 }
 
 //===========================================================================
@@ -322,7 +329,6 @@ void requestAndPrintPacket(uint8_t I2C_target_address,
     while (Wire.available()) {
         SERIAL_PROTOCOL(Wire.read());
     }
-    SERIAL_EOL;
 }
 
 void requestAndPrintSerial(uint8_t I2C_target_address) {

--- a/Marlin/Voxel8_I2C_Commands.h
+++ b/Marlin/Voxel8_I2C_Commands.h
@@ -40,6 +40,7 @@
 #define EEPROM_READ_PRGMR       0x12
 #define EEPROM_READ_ERR         0x13
 #define EEPROM_READ_FRMWRE      0x14
+#define CLEAR_ERROR             0x15
 
 //===========================================================================
 //============================= Public Functions ============================
@@ -129,5 +130,11 @@ void I2C__GetErrorCode(uint8_t cartridge);
  * @parameter cartridge           Address of the target (cartridge)
  */ 
 void I2C__GetFirmwareVersion(uint8_t cartridge);
+
+/**
+ * Clear the error flag for a particular cartridge if it's set
+ * @parameter cartridge           Address of the target (cartridge)
+ */ 
+void I2C__ClearError(uint8_t cartridge);
 
 #endif  // MARLIN_VOXEL8_I2C_COMMANDS_H_


### PR DESCRIPTION
Add heartbeat to read cartridge errors with every call of M105, allowing us to diagnose errors with the cartridges 