### PR TITLE
Revert back to standard arduino library

### DIFF
--- a/Marlin/Voxel8_I2C_Commands.cpp
+++ b/Marlin/Voxel8_I2C_Commands.cpp
@@ -344,11 +344,12 @@ void requestAndPrintPacket(uint8_t I2C_target_address,
     else {
       while (Wire.available()) {
         SERIAL_PROTOCOL(Wire.read());
+/* This block used to call a modified Arduino library, no longer necessary
         if (Wire.twi_getTimeoutFlag()) {
           SERIAL_PROTOCOL(" I2C Timeout occurred ");
           SERIAL_PROTOCOL(Wire.twi_getTimeoutFlag());
           Wire.twi_resetTimeoutFlag();
-        }
+        }*/
       }
     }
 }


### PR DESCRIPTION
Building currently fails with stock arduino because of this block, which is no longer necessary... commenting out for now to get master functional again.