### PR TITLE
Renaming I2C Commands

### DIFF
--- a/Marlin/Voxel8_I2C_Commands.cpp
+++ b/Marlin/Voxel8_I2C_Commands.cpp
@@ -95,7 +95,7 @@ void I2C__SetFanDrive0PWM(uint8_t fanSpeed) {
     }
 
     // Send message
-    writeThreeBytePacket(CART_HOLDER_ADDR, SET_FAN_DRIVE_0_PWM,
+    writeThreeBytePacket(CART_HOLDER_ADDR, SET_FAN_DRIVE_PWM,
                          I2C_EMPTY_ADDRESS, fanSpeed);
 
     // Send information to Octoprint
@@ -113,7 +113,7 @@ void I2C__SetFanOff(void) {
     uint8_t fanSpeed = 0;
 
     // Send message
-    writeThreeBytePacket(CART_HOLDER_ADDR, SET_FAN_DRIVE_0_PWM,
+    writeThreeBytePacket(CART_HOLDER_ADDR, SET_FAN_DRIVE_PWM,
                          I2C_EMPTY_ADDRESS, fanSpeed);
 
     // Send information to Octoprint
@@ -131,7 +131,7 @@ void I2C__SetFanOff(void) {
 void I2C__ToggleUV(uint8_t data) {
 
     // Send message
-    writeThreeBytePacket(CART_HOLDER_ADDR, SET_LED_UV_0_PWM,
+    writeThreeBytePacket(CART_HOLDER_ADDR, SET_LED_UV_PWM,
                          I2C_EMPTY_ADDRESS, data);
 
     // Send information to Octoprint

--- a/Marlin/Voxel8_I2C_Commands.h
+++ b/Marlin/Voxel8_I2C_Commands.h
@@ -26,11 +26,11 @@
 #define I2C_EMPTY_DATA          0xFF
 
 // I2C Commands
-#define SET_FAN_DRIVE_0_PWM     0x01
+#define SET_FAN_DRIVE_PWM       0x01
 #define RESERVED_CMD_02         0x02
-#define SET_LED_WHITE_1_PWM     0x03
-#define SET_LED_RED_0_PWM       0x04
-#define SET_LED_UV_0_PWM        0x05
+#define SET_LED_WHITE_PWM       0x03
+#define SET_LED_RED_PWM         0x04
+#define SET_LED_UV_PWM          0x05
 #define EEPROM_WRITE            0x06
 #define EEPROM_READ             0x07
 #define EEPROM_READ_SERIAL      0x08


### PR DESCRIPTION
Renaming I2C commands to make them consistent with the cartridges