### PR TITLE
Initial commit, disables maxtemp error if cartridge check is disabled

### DIFF
--- a/Marlin/Cartridge.cpp
+++ b/Marlin/Cartridge.cpp
@@ -156,6 +156,10 @@ void Cartridge__SetPresentCheck(bool value) {
 	cartridgeRemovalCheckEnabled = value;
 }
 
+bool Cartridge__GetPresentCheck(void) {
+    return cartridgeRemovalCheckEnabled;
+}
+
 //===========================================================================
 //============================ Private Functions ============================
 //===========================================================================

--- a/Marlin/Cartridge.h
+++ b/Marlin/Cartridge.h
@@ -58,4 +58,5 @@
   */
   void Cartridge__SetPresentCheck(bool value);
 
+  bool Cartridge__GetPresentCheck(void);
 #endif  // MARLIN_CARTRIDGE_H_

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -511,13 +511,15 @@ inline void _temp_error(int e, const char *serial_msg, const char *lcd_msg) {
 
 void max_temp_error(uint8_t e) {
 // Temp error has been reset
-  if (time_since_last_err[e] == 0) {
-    time_since_last_err[e] = millis();
-  }
-// There has been a recent error, if was more than a second ago, it is probably an error
-  else if (millis() > time_since_last_err[e] + TEMP_ERROR_INTERVAL) {
-    if(!Cartridge__FFFNotPresentHysteresis()) 
-      _temp_error(e, PSTR(MSG_T_MAXTEMP), PSTR(MSG_ERR_MAXTEMP));
+  if (Cartridge__GetPresentCheck()){
+    if (time_since_last_err[e] == 0) {
+      time_since_last_err[e] = millis();
+    }
+  // There has been a recent error, if was more than a second ago, it is probably an error
+    else if (millis() > time_since_last_err[e] + TEMP_ERROR_INTERVAL) {
+      if(!Cartridge__FFFNotPresentHysteresis()) 
+        _temp_error(e, PSTR(MSG_T_MAXTEMP), PSTR(MSG_ERR_MAXTEMP));
+    }
   }
 }
 


### PR DESCRIPTION
Self explanatory, makes sure we don't hit a max temp error when we think cartridge check is disabled. This will ideally be replaced by self identifying cartridges