### PR TITLE
Add proper handling for Wire library on build script error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,18 +1,43 @@
 #!/bin/bash
 # Correct Syntax: ./build.sh [port [*upload | verify]]
 
+cleanup()
+{
+  if [ ! "$OPERATING_SYSTEM" = "Linux" ]; then
+    rm -rf ./build/
+    if [ -d "$ARDUINO_DEP/variants/rambo_backup" ]; then
+      rm -rf "$ARDUINO_DEP/variants/rambo/"
+      mv "$ARDUINO_DEP/variants/rambo_backup/" "$ARDUINO_DEP/variants/rambo/"
+    fi
+    if [ -f "$ARDUINO_DEP/boards_backup.txt" ]; then
+      rm "$ARDUINO_DEP/boards.txt"
+      mv "$ARDUINO_DEP/boards_backup.txt" "$ARDUINO_DEP/boards.txt"
+    fi
+  else
+    if [ -f ./.build/mega2560/firmware.hex ]; then
+      rm ./.build/mega2560/firmware.hex
+    fi
+    if [ -d "$ARDUINO_DEP/variants/standard_backup" ]; then
+      sudo rm -rf "$ARDUINO_DEP/variants/standard/"
+      sudo mv "$ARDUINO_DEP/variants/standard_backup/" "$ARDUINO_DEP/variants/standard/"
+    fi
+    if [ -f "$ARDUINO_DEP/boards_backup.txt" ]; then
+      sudo rm "$ARDUINO_DEP/boards.txt"
+      sudo mv "$ARDUINO_DEP/boards_backup.txt" "$ARDUINO_DEP/boards.txt"
+    fi
+    if [ -d "$HERE/Wire-backup" ]; then
+      cd /usr/share/arduino/libraries
+      sudo rm -rf Wire
+      sudo mv "$HERE/Wire-backup" Wire
+      cd "$HERE"
+    fi
+  fi
+}
+
 abort()
 {
-    if [ "$OPERATING_SYSTEM" = "Linux" ]; then
-      echo "Moving old Wire library back..." >&2
-      if [ -d "$HERE/Wire-backup" ]; then
-        cd /usr/share/arduino/libraries
-        sudo rm -rf Wire
-        sudo mv "$HERE/Wire-backup" Wire
-        cd "$HERE"
-      fi
-    fi
-    echo "Exiting..." >&2
+    cleanup
+    echo "Build files cleaned up, exiting..." >&2
     exit 1
 }
 
@@ -261,31 +286,6 @@ if [ ! "$OPERATING_SYSTEM" = "Linux" ]; then
   cp "$HERE/build/Marlin.cpp.hex" "$HERE/firmware.hex"
 fi
 
-# Clean Up
-if [ ! "$OPERATING_SYSTEM" = "Linux" ]; then
-  rm -rf ./build/
-  if [ -d "$ARDUINO_DEP/variants/rambo_backup" ]; then
-    rm -rf "$ARDUINO_DEP/variants/rambo/"
-    mv "$ARDUINO_DEP/variants/rambo_backup/" "$ARDUINO_DEP/variants/rambo/"
-  fi
-  if [ -f "$ARDUINO_DEP/boards_backup.txt" ]; then
-    rm "$ARDUINO_DEP/boards.txt"
-    mv "$ARDUINO_DEP/boards_backup.txt" "$ARDUINO_DEP/boards.txt"
-  fi
-else 
-  rm ./.build/mega2560/firmware.hex
-  if [ -d "$ARDUINO_DEP/variants/standard_backup" ]; then
-    sudo rm -rf "$ARDUINO_DEP/variants/standard/"
-    sudo mv "$ARDUINO_DEP/variants/standard_backup/" "$ARDUINO_DEP/variants/standard/"
-  fi
-  if [ -f "$ARDUINO_DEP/boards_backup.txt" ]; then
-    sudo rm "$ARDUINO_DEP/boards.txt"
-    sudo mv "$ARDUINO_DEP/boards_backup.txt" "$ARDUINO_DEP/boards.txt"
-  fi
-  cd /usr/share/arduino/libraries
-  sudo rm -rf Wire
-  sudo mv "$HERE/Wire-backup" Wire
-  cd "$HERE"
-fi
+cleanup
 
 trap : 0

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,23 @@
 #!/bin/bash
 # Correct Syntax: ./build.sh [port [*upload | verify]]
+
+abort()
+{
+    if [ "$OPERATING_SYSTEM" = "Linux" ]; then
+      echo "Moving old Wire library back..." >&2
+      if [ -d "$HERE/Wire-backup" ]; then
+        cd /usr/share/arduino/libraries
+        sudo rm -rf Wire
+        sudo mv "$HERE/Wire-backup" Wire
+        cd "$HERE"
+      fi
+    fi
+    echo "Exiting..." >&2
+    exit 1
+}
+
+trap 'abort' 0
+
 set -e
 HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$HERE"
@@ -103,7 +121,7 @@ if [ "$OPERATING_SYSTEM" = "Linux" ]; then
   rm -rf ./libraries/
   cd /usr/share/arduino/libraries
   if [ -d "Wire" ]; then
-    sudo mv Wire "$HERE/Wire"
+    sudo mv Wire "$HERE/Wire-backup"
   fi
   sudo cp -r "$HERE/ArduinoAddons/Arduino_1.6.x/hardware/marlin/avr/libraries/Wire" Wire
   cd "$HERE"
@@ -266,6 +284,8 @@ else
   fi
   cd /usr/share/arduino/libraries
   sudo rm -rf Wire
-  sudo mv "$HERE/Wire" Wire
+  sudo mv "$HERE/Wire-backup" Wire
   cd "$HERE"
 fi
+
+trap : 0


### PR DESCRIPTION
With the changes I introduced in 3e1adfc, any build script errors past
the point of backing up the stock Arduino library would result in a
dirty state... this should catch any failures and move the stock
library back to its proper home.