### PR TITLE
Storing long strings in flash, to free up ram.

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -763,7 +763,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //
 // M100 Free Memory Watcher
 //
-//#define M100_FREE_MEMORY_WATCHER // uncomment to add the M100 Free Memory Watcher for debug purpose
+// #define M100_FREE_MEMORY_WATCHER // uncomment to add the M100 Free Memory Watcher for debug purpose
 
 // @section temperature
 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -755,6 +755,9 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //define this to enable EEPROM support
 #define EEPROM_SETTINGS
 
+// RAM checking
+//#define RAM_DEBUG
+
 #if ENABLED(EEPROM_SETTINGS)
   // To disable EEPROM Serial responses and decrease program space by ~1700 byte: comment this out:
   #define EEPROM_CHITCHAT // Please keep turned on if you can.

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -779,6 +779,8 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define ABS_PREHEAT_HPB_TEMP 110
 #define ABS_PREHEAT_FAN_SPEED 0   // Insert Value between 0 and 255
 
+// Testing and Debugging
+// #define DEBUG_TEST_PINS
 //==============================LCD and SD support=============================
 // @section lcd
 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -755,9 +755,6 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //define this to enable EEPROM support
 #define EEPROM_SETTINGS
 
-// RAM checking
-//#define RAM_DEBUG
-
 #if ENABLED(EEPROM_SETTINGS)
   // To disable EEPROM Serial responses and decrease program space by ~1700 byte: comment this out:
   #define EEPROM_CHITCHAT // Please keep turned on if you can.
@@ -779,8 +776,6 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define ABS_PREHEAT_HPB_TEMP 110
 #define ABS_PREHEAT_FAN_SPEED 0   // Insert Value between 0 and 255
 
-// Testing and Debugging
-// #define DEBUG_TEST_PINS
 //==============================LCD and SD support=============================
 // @section lcd
 

--- a/Marlin/HeatedBed.cpp
+++ b/Marlin/HeatedBed.cpp
@@ -54,17 +54,17 @@ bool HeatedBed__PresentCheck(void) {
 
 void HeatedBed__SetPresentCheck(bool value) {
 	if (value == true) {
-		SERIAL_PROTOCOL("Heated Bed Check Enabled");
+		SERIAL_PROTOCOLPGM("Heated Bed Check Enabled");
 		SERIAL_EOL;
 		bedRemovalCheckEnabled = 1;
 	}
 	else if (value == false) {
-		SERIAL_PROTOCOL("Heated Bed Check Disabled");
+		SERIAL_PROTOCOLPGM("Heated Bed Check Disabled");
 		SERIAL_EOL;
 		bedRemovalCheckEnabled = 0;
 	}
 	else {
-		SERIAL_PROTOCOL("Invalid value for Heated Bed Check Set");
+		SERIAL_PROTOCOLPGM("Invalid value for Heated Bed Check Set");
 		SERIAL_EOL;
 		return;
 	}
@@ -81,9 +81,9 @@ void heatedBedRemovedError(void) {
         quickStop();
         disable_all_heaters();
         disable_all_steppers();
-        SERIAL_PROTOCOL("Heated Bed Removed!");
+        SERIAL_PROTOCOLPGM("Heated Bed Removed!");
         SERIAL_EOL;
-        SERIAL_ECHOLN("// action:cancel");
+        SERIAL_PROTOCOLLNPGM("// action:cancel");
     }
     timeSinceLastRemoval = millis();
 }

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -108,6 +108,7 @@ FORCE_INLINE void serialprintPGM(const char *str) {
   }
 }
 
+int freeRam ();
 void get_command();
 
 void idle(); // the standard idle routine calls manage_inactivity(false)

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -107,8 +107,10 @@ FORCE_INLINE void serialprintPGM(const char *str) {
     str++;
   }
 }
-
-int freeRam ();
+extern "C"
+{
+  int freeMemory();
+}
 void get_command();
 
 void idle(); // the standard idle routine calls manage_inactivity(false)

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -488,12 +488,6 @@ void plan_arc(float target[NUM_AXIS], float *offset, uint8_t clockwise);
 
 bool setTargetedHotend(int code);
 
-int freeRam () {
-  extern int __heap_start, *__brkval; 
-  int v; 
-  return (int) &v - (__brkval == 0 ? (int) &__heap_start : (int) __brkval); 
-}
-
 void serial_echopair_P(const char *s_P, int v)           { serialprintPGM(s_P); SERIAL_ECHO(v); }
 void serial_echopair_P(const char *s_P, long v)          { serialprintPGM(s_P); SERIAL_ECHO(v); }
 void serial_echopair_P(const char *s_P, float v)         { serialprintPGM(s_P); SERIAL_ECHO(v); }
@@ -3638,10 +3632,12 @@ inline void gcode_M105() {
     SERIAL_PROTOCOLPGM(" C1: ");
     I2C__GetErrorCode(CART1_ADDR);
   }
-  
-  SERIAL_PROTOCOLPGM(" FREE RAM: ");
-  SERIAL_PROTOCOL(freeRam());
 
+#if ENABLED(RAM_DEBUG)
+  SERIAL_PROTOCOLPGM(" FREE RAM: ");
+  SERIAL_PROTOCOL(freeMemory());
+#endif  // ENABLED(RAM_DEBUG)
+  
   SERIAL_EOL;
 }
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -488,6 +488,12 @@ void plan_arc(float target[NUM_AXIS], float *offset, uint8_t clockwise);
 
 bool setTargetedHotend(int code);
 
+int freeRam () {
+  extern int __heap_start, *__brkval; 
+  int v; 
+  return (int) &v - (__brkval == 0 ? (int) &__heap_start : (int) __brkval); 
+}
+
 void serial_echopair_P(const char *s_P, int v)           { serialprintPGM(s_P); SERIAL_ECHO(v); }
 void serial_echopair_P(const char *s_P, long v)          { serialprintPGM(s_P); SERIAL_ECHO(v); }
 void serial_echopair_P(const char *s_P, float v)         { serialprintPGM(s_P); SERIAL_ECHO(v); }
@@ -624,10 +630,15 @@ void setup_powerhold() {
 
 void setup_cartridgeidpins(void){
   #if HAS_CARTRIDGE_ID
-    SET_OUTPUT(CART1_SIG1_PIN)
-    SET_INPUT(CART0_SIG2_PIN)
-    SET_INPUT(CART1_SIG2_PIN)
+    SET_OUTPUT(CART1_SIG1_PIN);
+    SET_INPUT(CART0_SIG2_PIN);
+    SET_INPUT(CART1_SIG2_PIN);
   #endif
+}
+
+void setup_testpins(void){
+    OUT_WRITE(TEST_POINT_83, LOW);
+    SET_OUTPUT(TEST_POINT_83);
 }
 
 /*
@@ -744,6 +755,7 @@ void setup() {
   setup_filrunoutpin();
   setup_powerhold();
   setup_cartridgeidpins();
+  setup_testpins();
 
   #if HAS_STEPPER_RESET
     disableStepperDrivers();
@@ -3615,16 +3627,20 @@ inline void gcode_M105() {
     }
   #endif
 
-  // Get error codes from present cartridges
-  // if (Cartridge__Present(0)) {
-  //   SERIAL_PROTOCOL(" C0: ");
-  //   I2C__GetErrorCode(CART0_ADDR);
-  // }
 
-  // if (Cartridge__Present(1)) {
-  //   SERIAL_PROTOCOL(" C1: ");
-  //   I2C__GetErrorCode(CART1_ADDR);
-  // }
+  //Get error codes from present cartridges
+  if (Cartridge__Present(0)) {
+    SERIAL_PROTOCOLPGM(" C0: ");
+    I2C__GetErrorCode(CART0_ADDR);
+  }
+
+  if (Cartridge__Present(1)) {
+    SERIAL_PROTOCOLPGM(" C1: ");
+    I2C__GetErrorCode(CART1_ADDR);
+  }
+  
+  SERIAL_PROTOCOLPGM(" FREE RAM: ");
+  SERIAL_PROTOCOL(freeRam());
 
   SERIAL_EOL;
 }
@@ -4894,7 +4910,7 @@ inline void gcode_M243() {
   }
 
   if (!hasC){
-    SERIAL_ECHOLNPGM("No cartridge address given");
+    SERIAL_ECHOLNPGM("No addr given");
     return;
   }
   if (!hasD){
@@ -4902,7 +4918,7 @@ inline void gcode_M243() {
     return;
   }
   if (!hasE){
-    SERIAL_ECHOLNPGM("No eeprom address given");
+    SERIAL_ECHOLNPGM("No eeprom addr given");
     return;
   }
 
@@ -5038,7 +5054,7 @@ inline void gcode_M248() {
   }
 
   if (!hasE){
-    SERIAL_ECHOLNPGM("Enable (E1) or Disable (E0) not given");
+    SERIAL_ECHOLNPGM("(E1) or (E0) not given");
     return;
   }
 }
@@ -5120,9 +5136,9 @@ inline void gcode_M252() {
     }
     else if (servo_index >= 0) {
       SERIAL_PROTOCOL(MSG_OK);
-      SERIAL_PROTOCOL(" Servo ");
+      SERIAL_PROTOCOLPGM(" Servo ");
       SERIAL_PROTOCOL(servo_index);
-      SERIAL_PROTOCOL(": ");
+      SERIAL_PROTOCOLPGM(": ");
       SERIAL_PROTOCOL(servo[servo_index].read());
       SERIAL_EOL;
     }
@@ -5180,14 +5196,14 @@ inline void gcode_M252() {
         SERIAL_PROTOCOL(" e:"); // specify extruder in serial output
         SERIAL_PROTOCOL(e);
       #endif // PID_PARAMS_PER_EXTRUDER
-      SERIAL_PROTOCOL(" p:");
+      SERIAL_PROTOCOLPGM(" p:");
       SERIAL_PROTOCOL(PID_PARAM(Kp, e));
-      SERIAL_PROTOCOL(" i:");
+      SERIAL_PROTOCOLPGM(" i:");
       SERIAL_PROTOCOL(unscalePID_i(PID_PARAM(Ki, e)));
-      SERIAL_PROTOCOL(" d:");
+      SERIAL_PROTOCOLPGM(" d:");
       SERIAL_PROTOCOL(unscalePID_d(PID_PARAM(Kd, e)));
       #if ENABLED(PID_ADD_EXTRUSION_RATE)
-        SERIAL_PROTOCOL(" c:");
+        SERIAL_PROTOCOLPGM(" c:");
         //Kc does not have scaling applied above, or in resetting defaults
         SERIAL_PROTOCOL(PID_PARAM(Kc, e));
       #endif
@@ -5210,11 +5226,11 @@ inline void gcode_M252() {
 
     updatePID();
     SERIAL_PROTOCOL(MSG_OK);
-    SERIAL_PROTOCOL(" p:");
+    SERIAL_PROTOCOLPGM(" p:");
     SERIAL_PROTOCOL(bedKp);
-    SERIAL_PROTOCOL(" i:");
+    SERIAL_PROTOCOLPGM(" i:");
     SERIAL_PROTOCOL(unscalePID_i(bedKi));
-    SERIAL_PROTOCOL(" d:");
+    SERIAL_PROTOCOLPGM(" d:");
     SERIAL_PROTOCOL(unscalePID_d(bedKd));
     SERIAL_EOL;
   }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -622,7 +622,7 @@ void setup_powerhold() {
   #endif
 }
 
-void setup_cartridgeidpins(void){
+void setup_cartridgeidpins(void) {
   #if HAS_CARTRIDGE_ID
     SET_OUTPUT(CART1_SIG1_PIN);
     SET_INPUT(CART0_SIG2_PIN);
@@ -630,10 +630,12 @@ void setup_cartridgeidpins(void){
   #endif
 }
 
-void setup_testpins(void){
-    OUT_WRITE(TEST_POINT_83, LOW);
-    SET_OUTPUT(TEST_POINT_83);
+#if ENABLED(DEBUG_TEST_PINS)
+void setup_testpins(void) {
+    OUT_WRITE(TEST_POINT_83_PIN, LOW);
+    SET_OUTPUT(TEST_POINT_83_PIN);
 }
+#endif // ENABLED(DEBUG_TEST_PINS)
 
 /*
   Enable 24V to fans, E-reg, Cartridge Holder, Cartridges
@@ -749,7 +751,10 @@ void setup() {
   setup_filrunoutpin();
   setup_powerhold();
   setup_cartridgeidpins();
-  setup_testpins();
+
+  #if ENABLED(DEBUG_TEST_PINS)
+    setup_testpins();
+  #endif // ENABLED(DEBUG_TEST_PINS)
 
   #if HAS_STEPPER_RESET
     disableStepperDrivers();
@@ -3623,21 +3628,21 @@ inline void gcode_M105() {
 
 
   //Get error codes from present cartridges
-  if (Cartridge__Present(0)) {
-    SERIAL_PROTOCOLPGM(" C0: ");
-    I2C__GetErrorCode(CART0_ADDR);
-  }
+  // if (Cartridge__Present(0)) {
+  //   SERIAL_PROTOCOLPGM(" C0: ");
+  //   I2C__GetErrorCode(CART0_ADDR);
+  // }
 
-  if (Cartridge__Present(1)) {
-    SERIAL_PROTOCOLPGM(" C1: ");
-    I2C__GetErrorCode(CART1_ADDR);
-  }
+  // if (Cartridge__Present(1)) {
+  //   SERIAL_PROTOCOLPGM(" C1: ");
+  //   I2C__GetErrorCode(CART1_ADDR);
+  // }
 
 #if ENABLED(RAM_DEBUG)
   SERIAL_PROTOCOLPGM(" FREE RAM: ");
   SERIAL_PROTOCOL(freeMemory());
 #endif  // ENABLED(RAM_DEBUG)
-  
+
   SERIAL_EOL;
 }
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -630,12 +630,12 @@ void setup_cartridgeidpins(void) {
   #endif
 }
 
-#if ENABLED(DEBUG_TEST_PINS)
+#ifdef DEBUG
 void setup_testpins(void) {
     OUT_WRITE(TEST_POINT_83_PIN, LOW);
     SET_OUTPUT(TEST_POINT_83_PIN);
 }
-#endif // ENABLED(DEBUG_TEST_PINS)
+#endif // DEBUG
 
 /*
   Enable 24V to fans, E-reg, Cartridge Holder, Cartridges
@@ -752,9 +752,9 @@ void setup() {
   setup_powerhold();
   setup_cartridgeidpins();
 
-  #if ENABLED(DEBUG_TEST_PINS)
+  #ifdef DEBUG
     setup_testpins();
-  #endif // ENABLED(DEBUG_TEST_PINS)
+  #endif // DEBUG
 
   #if HAS_STEPPER_RESET
     disableStepperDrivers();
@@ -3638,10 +3638,10 @@ inline void gcode_M105() {
   //   I2C__GetErrorCode(CART1_ADDR);
   // }
 
-#if ENABLED(RAM_DEBUG)
+#ifdef DEBUG
   SERIAL_PROTOCOLPGM(" FREE RAM: ");
   SERIAL_PROTOCOL(freeMemory());
-#endif  // ENABLED(RAM_DEBUG)
+#endif  // DEBUG
 
   SERIAL_EOL;
 }

--- a/Marlin/language.h
+++ b/Marlin/language.h
@@ -213,7 +213,7 @@
 #define MSG_T_THERMAL_RUNAWAY               "Thermal Runaway"
 #define MSG_T_MAXTEMP                       "MAXTEMP triggered"
 #define MSG_T_MINTEMP                       "MINTEMP triggered"
-#define MSG_T_CARTRIDGE_REMOVED             "Cartridge Removed. Print will not continue, and heating is disabled"
+#define MSG_T_CARTRIDGE_REMOVED             "Cartridge Removed. Print cancelled, heating disabled"
 #define MSG_T_CARTRIDGE_REMOVED_HEATING     "An FFF Cartridge has been removed, will not heat"
 #define MSG_PNEUMATIC_PUMP_OFF              ": Pressure pump turned off, MAX/MIN value exceeded!!"
 

--- a/Marlin/pins_VOXEL8_GEN3C2.h
+++ b/Marlin/pins_VOXEL8_GEN3C2.h
@@ -170,3 +170,9 @@ DIGITAL POTENTIOMETER PINS
   //Filip added pin for Filament sensor analog input 
   #define FILMNT_SENS_PIN       80  //! Monitor filament low
 #endif
+
+/*************************
+    TEST PINS
+*************************/
+
+#define TEST_POINT_83           83

--- a/Marlin/pins_VOXEL8_GEN3C2.h
+++ b/Marlin/pins_VOXEL8_GEN3C2.h
@@ -174,7 +174,7 @@ DIGITAL POTENTIOMETER PINS
 /*************************
     TEST PINS
 *************************/
-#if ENABLED(DEBUG_TEST_PINS)
+#ifdef DEBUG
   #define TEST_POINT_83_PIN     83
-#endif  // ENABLED(DEBUG_TEST_PINS)
+#endif  // DEBUG
     

--- a/Marlin/pins_VOXEL8_GEN3C2.h
+++ b/Marlin/pins_VOXEL8_GEN3C2.h
@@ -174,5 +174,7 @@ DIGITAL POTENTIOMETER PINS
 /*************************
     TEST PINS
 *************************/
-
-#define TEST_POINT_83           83
+#if ENABLED(DEBUG_TEST_PINS)
+  #define TEST_POINT_83_PIN     83
+#endif  // ENABLED(DEBUG_TEST_PINS)
+    

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1915,7 +1915,7 @@ ISR(TIMER0_COMPB_vect) {
   #endif //BABYSTEPPING
 
     int freeMem = freeMemory();
-    if (freeMem < 400) {
+    if (freeMem < 250) {
       SERIAL_PROTOCOLPGM(" Free RAM Low: ");
       SERIAL_PROTOCOL(freeMem);
       SERIAL_PROTOCOLPGM("// action:cancel");

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1913,13 +1913,14 @@ ISR(TIMER0_COMPB_vect) {
       }
     }
   #endif //BABYSTEPPING
-  int frees = freeRam(); 
-  if (frees < 400) {
-    SERIAL_PROTOCOLPGM(" Free RAM: ");
-    SERIAL_PROTOCOL(frees);
-    SERIAL_EOL;
-  }
 
+    int freeMem = freeMemory();
+    if (freeMem < 400) {
+      SERIAL_PROTOCOLPGM(" Free RAM Low: ");
+      SERIAL_PROTOCOL(freeMem);
+      SERIAL_PROTOCOLPGM("// action:cancel");
+      SERIAL_EOL;
+    }
 }
 
 #if ENABLED(PIDTEMP)

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1913,6 +1913,13 @@ ISR(TIMER0_COMPB_vect) {
       }
     }
   #endif //BABYSTEPPING
+  int frees = freeRam(); 
+  if (frees < 400) {
+    SERIAL_PROTOCOLPGM(" Free RAM: ");
+    SERIAL_PROTOCOL(frees);
+    SERIAL_EOL;
+  }
+
 }
 
 #if ENABLED(PIDTEMP)


### PR DESCRIPTION
![little-black-ram v7384](https://cloud.githubusercontent.com/assets/3892443/15122428/14cf6c88-15ed-11e6-92ea-d8ad7a93d1a3.jpg)


We were beginning to run out of ram, as I didn't realize this was an
issue. We have done some refactoring to get long strings out of ram and
into flash memory, which should fix a significant number of our issues.

This also adds some RAM diagnostics. Now, we have a quick way to check available ram in the form of freeRam. This is checked in M105 now, and in the temperature interrupt. If the available ram drops below a set threshold, we'll report it in the interrupt. Typically, marlin tends to have about 500-600 bits of ram allocated after the program starts, so it's not reported by the compiler. Keep this in mind when writing features.

REQUIREMENTS
* Unit Tested ----------------------------- PASSED
* Alignment ------------------------------- PASSED