### PR TITLE
Metalworks E-Regulator Setting

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -392,8 +392,9 @@ Here are some standard links for getting your machine calibrated:
  // ---------------------------------
  // 0 - No Pressure Sensor Used
  // 1 - Built-in Pressure Transducer (ITV0050-2UL)
+ // 2 - Built-in Pressure Transducer (Regtronics M5)
 
-  #define E_REGULATOR_SENSOR 1
+  #define E_REGULATOR_SENSOR 2
   #define DAC_I2C
  // 130 psi is max settable pressure for e-regulator
   #define OUTPUT_PSI_MAX     130.0 

--- a/Marlin/Regulator.cpp
+++ b/Marlin/Regulator.cpp
@@ -11,21 +11,26 @@
 
 // Set the output pressure (in psi) of the regulator.
 void setOutputPressure(float desired_pressure) {
-    uint16_t digital_val = 0;
-    // Increasing pressure
-    if(desired_pressure > pressureRegulator()) {
-        // Add half of hysteresis range to desired pressure
-        desired_pressure += (REG_HYSTERESIS/2.0);
-    }
-    // Decreasing pressure
-    else if(desired_pressure < pressureRegulator()) {
-        // Subtract half of hysteresis range from desired pressure
-        desired_pressure -= (REG_HYSTERESIS/2.0);
-    }
+  uint16_t digital_val = 0;
+  // Set to zero
+  if (desired_pressure <= (REG_OFFSET + REG_HYSTERESIS)) {
+    digital_val = 0;
+  }
+  // Increasing pressure
+  else if (desired_pressure > pressureRegulator()) {
+    // Add half of hysteresis range to desired pressure
+    digital_val = (uint16_t)(BITS_PER_PSI *
+                             (desired_pressure - REG_OFFSET + REG_HYSTERESIS));
+  }
+  // Decreasing pressure
+  else if (desired_pressure < pressureRegulator()) {
+    // Subtract half of hysteresis range from desired pressure
+    digital_val = (uint16_t)(BITS_PER_PSI *
+                             (desired_pressure - REG_OFFSET - REG_HYSTERESIS));
+  }
 
-	digital_val = (uint16_t)(BITS_PER_PSI * (desired_pressure + MCP_CONST));
-	// Write value to DAC
-	DAC_write(MCP4725_I2C_ADDRESS, digital_val);
+  // Write value to DAC
+  DAC_write(MCP4725_I2C_ADDRESS, digital_val);
 }
 
-#endif // ENABLED(E_REGULATOR)
+#endif  // ENABLED(E_REGULATOR)

--- a/Marlin/Regulator.cpp
+++ b/Marlin/Regulator.cpp
@@ -18,13 +18,13 @@ void setOutputPressure(float desired_pressure) {
     }
     // Increasing pressure
     else if (desired_pressure > pressureRegulator()) {
-        // Add half of hysteresis range to desired pressure
+        // Add hysteresis value to desired pressure
         digital_val = (uint16_t)(BITS_PER_PSI *
                                  (desired_pressure - REG_OFFSET + REG_HYSTERESIS));
     }
     // Decreasing pressure
     else if (desired_pressure < pressureRegulator()) {
-        // Subtract half of hysteresis range from desired pressure
+        // Subtract hysteresis value from desired pressure
         digital_val = (uint16_t)(BITS_PER_PSI *
                                  (desired_pressure - REG_OFFSET - REG_HYSTERESIS));
     }

--- a/Marlin/Regulator.cpp
+++ b/Marlin/Regulator.cpp
@@ -11,26 +11,26 @@
 
 // Set the output pressure (in psi) of the regulator.
 void setOutputPressure(float desired_pressure) {
-  uint16_t digital_val = 0;
-  // Set to zero
-  if (desired_pressure <= (REG_OFFSET + REG_HYSTERESIS)) {
-    digital_val = 0;
-  }
-  // Increasing pressure
-  else if (desired_pressure > pressureRegulator()) {
-    // Add half of hysteresis range to desired pressure
-    digital_val = (uint16_t)(BITS_PER_PSI *
-                             (desired_pressure - REG_OFFSET + REG_HYSTERESIS));
-  }
-  // Decreasing pressure
-  else if (desired_pressure < pressureRegulator()) {
-    // Subtract half of hysteresis range from desired pressure
-    digital_val = (uint16_t)(BITS_PER_PSI *
-                             (desired_pressure - REG_OFFSET - REG_HYSTERESIS));
-  }
-
-  // Write value to DAC
-  DAC_write(MCP4725_I2C_ADDRESS, digital_val);
+    uint16_t digital_val = 0;
+    // Set to zero
+    if (desired_pressure <= (REG_OFFSET + REG_HYSTERESIS)) {
+        digital_val = 0;
+    }
+    // Increasing pressure
+    else if (desired_pressure > pressureRegulator()) {
+        // Add half of hysteresis range to desired pressure
+        digital_val = (uint16_t)(BITS_PER_PSI *
+                                 (desired_pressure - REG_OFFSET + REG_HYSTERESIS));
+    }
+    // Decreasing pressure
+    else if (desired_pressure < pressureRegulator()) {
+        // Subtract half of hysteresis range from desired pressure
+        digital_val = (uint16_t)(BITS_PER_PSI *
+                                 (desired_pressure - REG_OFFSET - REG_HYSTERESIS));
+    }
+    
+    // Write value to DAC
+    DAC_write(MCP4725_I2C_ADDRESS, digital_val);
 }
 
 #endif  // ENABLED(E_REGULATOR)

--- a/Marlin/Regulator.h
+++ b/Marlin/Regulator.h
@@ -13,11 +13,11 @@
 // PSI_MAX = 100
 // PSI_MIN = 2
 // BITS_PER_PSI = (2^n/(PSI_MAX - PSI_MIN)) / (R2/(R1 + R2)) = 41.92
-// Empirically tested at 43.76
+// Empirically tuned to 42.76
 
-#define BITS_PER_PSI    43.76
+#define BITS_PER_PSI    42.76
 
-#define REG_OFFSET      1.7  // psi
+#define REG_OFFSET      1.5  // psi
 #define REG_HYSTERESIS  0.0 // psi
 #define MCP_CONST       (REG_OFFSET - REG_HYSTERESIS)
 #define REGULATOR_LOW_P 2

--- a/Marlin/Regulator.h
+++ b/Marlin/Regulator.h
@@ -13,11 +13,11 @@
 // PSI_MAX = 100
 // PSI_MIN = 2
 // BITS_PER_PSI = (2^n/(PSI_MAX - PSI_MIN)) / (R2/(R1 + R2)) = 41.92
-// Empirically tuned to 42.76
+// Empirically tuned to 43.00
 
-#define BITS_PER_PSI    41.08
+#define BITS_PER_PSI    43.00
 
-#define REG_OFFSET      0.5 // psi
+#define REG_OFFSET      0.0  // psi
 #define REG_HYSTERESIS  0.0 // psi
 #define MCP_CONST       (REG_OFFSET - (REG_HYSTERESIS/2.0))
 #define REGULATOR_LOW_P 2

--- a/Marlin/Regulator.h
+++ b/Marlin/Regulator.h
@@ -8,14 +8,14 @@
 /*================================================================================*/
 // Calculation for BITS_PER_PSI:
 // R1 = 499
-// R2 (input impedance of sensor) = 10k
+// R2 (input impedance of sensor) = 168k
 // n = 12
 // BITS_PER_PSI = (2^n/OUTPUT_PSI_MAX) / (R2/(R1 + R2)) approx = 33.1
 
-#define BITS_PER_PSI    33.1
+#define BITS_PER_PSI    41.08
 
 #define REG_OFFSET      0.5 // psi
-#define REG_HYSTERESIS  0.2 // psi
+#define REG_HYSTERESIS  0.0 // psi
 #define MCP_CONST       (REG_OFFSET - (REG_HYSTERESIS/2.0))
 #define REGULATOR_LOW_P 2
 

--- a/Marlin/Regulator.h
+++ b/Marlin/Regulator.h
@@ -18,7 +18,7 @@
 
 #define REG_OFFSET      2  // psi
 #define REG_HYSTERESIS  0.0 // psi
-#define MCP_CONST       (REG_OFFSET - (REG_HYSTERESIS/2.0))
+#define MCP_CONST       (REG_OFFSET - REG_HYSTERESIS)
 #define REGULATOR_LOW_P 2
 
 /*================================================================================*/

--- a/Marlin/Regulator.h
+++ b/Marlin/Regulator.h
@@ -24,14 +24,13 @@
 
 #if (E_REGULATOR_SENSOR == 1)     // SMC E-Reg
     #define BITS_PER_PSI    33.1
-    #define REG_OFFSET      0.5   // psi
+    #define REG_OFFSET      0.25  // psi
     #define REG_HYSTERESIS  0.2   // psi
 #elif (E_REGULATOR_SENSOR == 2)   // Metalworks E-Reg
     #define BITS_PER_PSI    43.00
     #define REG_OFFSET      0.0   // psi
     #define REG_HYSTERESIS  0.0   // psi
 #endif // E_REGULATOR_SENSOR
-#define MCP_CONST       (REG_OFFSET - (REG_HYSTERESIS/2.0))
 #define REGULATOR_LOW_P 2
 
 /*================================================================================*/

--- a/Marlin/Regulator.h
+++ b/Marlin/Regulator.h
@@ -13,10 +13,11 @@
 // PSI_MAX = 100
 // PSI_MIN = 2
 // BITS_PER_PSI = (2^n/(PSI_MAX - PSI_MIN)) / (R2/(R1 + R2)) = 41.92
+// Empirically tested at 43.76
 
-#define BITS_PER_PSI    41.92
+#define BITS_PER_PSI    43.76
 
-#define REG_OFFSET      2  // psi
+#define REG_OFFSET      1.7  // psi
 #define REG_HYSTERESIS  0.0 // psi
 #define MCP_CONST       (REG_OFFSET - REG_HYSTERESIS)
 #define REGULATOR_LOW_P 2

--- a/Marlin/Regulator.h
+++ b/Marlin/Regulator.h
@@ -15,11 +15,11 @@
 // BITS_PER_PSI = (2^n/(PSI_MAX - PSI_MIN)) / (R2/(R1 + R2)) = 41.92
 // Empirically tuned to 42.76
 
-#define BITS_PER_PSI    42.76
+#define BITS_PER_PSI    41.08
 
-#define REG_OFFSET      1.5  // psi
+#define REG_OFFSET      0.5 // psi
 #define REG_HYSTERESIS  0.0 // psi
-#define MCP_CONST       (REG_OFFSET - REG_HYSTERESIS)
+#define MCP_CONST       (REG_OFFSET - (REG_HYSTERESIS/2.0))
 #define REGULATOR_LOW_P 2
 
 /*================================================================================*/

--- a/Marlin/Regulator.h
+++ b/Marlin/Regulator.h
@@ -10,11 +10,13 @@
 // R1 = 499
 // R2 (input impedance of sensor) = 168k
 // n = 12
-// BITS_PER_PSI = (2^n/OUTPUT_PSI_MAX) / (R2/(R1 + R2)) approx = 33.1
+// PSI_MAX = 100
+// PSI_MIN = 2
+// BITS_PER_PSI = (2^n/(PSI_MAX - PSI_MIN)) / (R2/(R1 + R2)) = 41.92
 
-#define BITS_PER_PSI    41.08
+#define BITS_PER_PSI    41.92
 
-#define REG_OFFSET      0.5 // psi
+#define REG_OFFSET      2  // psi
 #define REG_HYSTERESIS  0.0 // psi
 #define MCP_CONST       (REG_OFFSET - (REG_HYSTERESIS/2.0))
 #define REGULATOR_LOW_P 2

--- a/Marlin/Regulator.h
+++ b/Marlin/Regulator.h
@@ -10,9 +10,16 @@
 // R1 = 499
 // R2 (input impedance of sensor) = 168k
 // n = 12
+// Metalworks E-Reg Settings:
+// Type of input: 0/5 V
+// Measure unit: psi
 // PSI_MAX = 100
-// PSI_MIN = 2
-// BITS_PER_PSI = (2^n/(PSI_MAX - PSI_MIN)) / (R2/(R1 + R2)) = 41.92
+// PSI_MIN = 0
+// Minimal pression: 0
+// Speed adjust: 4
+// Filter analog input: 2
+// 
+// BITS_PER_PSI = (2^n/(PSI_MAX - PSI_MIN)) / (R2/(R1 + R2)) = 40.92
 // Empirically tuned to 43.00
 
 #define BITS_PER_PSI    43.00

--- a/Marlin/Regulator.h
+++ b/Marlin/Regulator.h
@@ -2,30 +2,35 @@
 #define REGULATOR_H
 
 #include "Arduino.h"
+#include "Configuration.h"
 
 /*================================================================================*/
 /* Definitions  */
 /*================================================================================*/
 // Calculation for BITS_PER_PSI:
 // R1 = 499
-// R2 (input impedance of sensor) = 168k
 // n = 12
 // Metalworks E-Reg Settings:
+// R2 (input impedance of sensor) = 168k
 // Type of input: 0/5 V
 // Measure unit: psi
 // PSI_MAX = 100
 // PSI_MIN = 0
-// Minimal pression: 0
 // Speed adjust: 4
 // Filter analog input: 2
 // 
 // BITS_PER_PSI = (2^n/(PSI_MAX - PSI_MIN)) / (R2/(R1 + R2)) = 40.92
 // Empirically tuned to 43.00
 
-#define BITS_PER_PSI    43.00
-
-#define REG_OFFSET      0.0  // psi
-#define REG_HYSTERESIS  0.0 // psi
+#if (E_REGULATOR_SENSOR == 1)     // SMC E-Reg
+    #define BITS_PER_PSI    33.1
+    #define REG_OFFSET      0.5   // psi
+    #define REG_HYSTERESIS  0.2   // psi
+#elif (E_REGULATOR_SENSOR == 2)   // Metalworks E-Reg
+    #define BITS_PER_PSI    43.00
+    #define REG_OFFSET      0.0   // psi
+    #define REG_HYSTERESIS  0.0   // psi
+#endif // E_REGULATOR_SENSOR
 #define MCP_CONST       (REG_OFFSET - (REG_HYSTERESIS/2.0))
 #define REGULATOR_LOW_P 2
 

--- a/Marlin/thermistortables.h
+++ b/Marlin/thermistortables.h
@@ -1206,6 +1206,12 @@ const short regulatortable_1[][2] PROGMEM = {
 };
 #endif
 
+#if (E_REGULATOR_SENSOR == 2) // Internal Pressure Sensor LUT for Regtronic M5
+const short regulatortable_2[][2] PROGMEM = {
+  {0*OVERSAMPLENR,       2},
+  {1023*OVERSAMPLENR, 1500},
+};
+#endif
 
 #define _TT_NAME(_N) temptable_ ## _N
 #define TT_NAME(_N) _TT_NAME(_N)

--- a/tests/test_i2c.py
+++ b/tests/test_i2c.py
@@ -5,6 +5,33 @@ import numpy as np
 from mecode import G
 from time import sleep
 import re
+from colorlog import ColoredFormatter
+import logging
+
+logging.basicConfig(level=logging.DEBUG,  # DEBUG, INFO, WARNING
+                    format='%(asctime)s %(levelname)-8s %(message)s',
+                    datefmt='%d-%m-%y %H:%M:%S',
+                    filename='console.log',
+                    filemode='w'
+                    )
+
+console = logging.StreamHandler()
+console.setLevel(logging.ERROR)
+formatter = ColoredFormatter(
+    "%(black,bg_white)s%(asctime)s%(reset)s %(log_color)s%(levelname)-8s%(reset)s %(white)s%(message)s",
+    datefmt='%d-%m-%y %H:%M:%S',
+    reset=True,
+    log_colors={
+        'DEBUG':    'cyan',
+        'INFO':     'green',
+        'WARNING':  'yellow',
+        'ERROR':    'red',
+        'CRITICAL': 'white,bg_red',
+    }
+)
+console.setFormatter(formatter)
+logging.getLogger('').addHandler(console)
+
 
 class I2CTestCase(unittest.TestCase):
 
@@ -14,8 +41,8 @@ class I2CTestCase(unittest.TestCase):
             aerotech_include=False,
             direct_write=True,
             direct_write_mode='serial',
-            #printer_port="/dev/tty.usbmodem1421",
-            printer_port="COM5",
+            # printer_port="/dev/tty.usbmodem1421",
+            printer_port="COM21",
         )
 
     def tearDown(self):
@@ -25,28 +52,90 @@ class I2CTestCase(unittest.TestCase):
         self.g.teardown()
         self.g = None
 
-    def commandparser(self,command, p1 = '', p2 = '', p3=''):
-    	g = self.g
-    	resp = g.write(command + ' ' + p1+ ' ' + p2 + ' ' + p3, resp_needed=True);
-    	print(str(command + ' ' + p1+ ' ' + p2 + ' ' + p3))
-    	testsplit = re.findall('Packet',resp)
-    	if len(testsplit):
-    		print("Dropped " + str(len(testsplit)) + " Packets from address " + str(p1))
-    	testsplit = re.findall('Timeout',resp)
-    	if len(testsplit):
-    		print(str(len(testsplit)) + " Timeouts from " + str(p1))
+    def commandparser(self, command, p1='', p2='', p3=''):
+        g = self.g
+        resp = g.write(
+            command + ' ' + p1 + ' ' + p2 + ' ' + p3, resp_needed=True)
+        logging.debug(str(command + ' ' + p1 + ' ' + p2 + ' ' + p3 +'  Response: ' + resp))
+        PacketSplit = re.findall('Packet', resp)
+        TimeoutSplit = re.findall('Timeout', resp)
+        if len(PacketSplit):
+            logging.error(
+                "Dropped " + str(len(PacketSplit)) + " Packets from address " + str(p1) + ". " + str(p1) + " is either not present or not communicating.")
+            resp = 0
+            self.assertEqual(len(PacketSplit), 0, "Dropped packets, target is either not connected or not programmed")
+        if len(TimeoutSplit):
+            logging.error(str(len(TimeoutSplit)) + " Timeouts from " + str(p1))
+            resp = 0
+            self.assertEqual(len(TimeoutSplit), 0, "Timed out I2C, one of the peripherals is likely holding the data line low")
+        return resp
+
+    def parseCartridgeStatus(self, cartridgeStatus, cartridgeNumber):
+        logging.info("%s Info", cartridgeNumber)
+        infoList = re.split('\W+', cartridgeStatus)
+        logging.debug(infoList)
+        logging.info("-------------------------------------")
+        logging.info("Cartridge Serial Number: %s", infoList[2])
+        logging.info("Cartridge Firmware Version: %s", infoList[18])
+        logging.info("Cartridge Programmer Station: %s", infoList[5])
+        logging.info("Cartridge Type: %s", infoList[8])
+        logging.info("Cartridge Size: %s", infoList[11])
+        logging.info("Cartridge Material: %s", infoList[14])
+
+        if (int(infoList[18]) == 255):
+            logging.error(
+                "%s FLASH not loaded properly, or cartridge is out of date", cartridgeNumber)
+            logging.info(' ')
+            self.assertNotEqual(int(infoList[18]), 255,"Cartridge FLASH not loaded properly, or cartridge is out of date")
+
+        if (int(infoList[8]) == 15) and (cartridgeNumber != "Cartridge Holder"):
+            logging.error("%s EEPROM not loaded properly", cartridgeNumber)
+            logging.info(' ')
+            self.assertNotEqual(int(infoList[8]), 15, "Cartridge EEPROM not loaded properly")
+        logging.info(' ')
     ###########################################################################
     #
     #                               Tests
     #
     ###########################################################################
 
-    def test_i2c(self):
-      	self.commandparser('M245','C0')
-      	self.commandparser('M245','C1')
-      	for i in range(0,30):
-      		string = 'E'+str(i)
-      		self.commandparser('M244','C0',string)
-      		self.commandparser('M244','C1',string)
+    def test_i2c_alltargets(self):
+        logging.info("Testing all I2C Targets")
+        for i in range(0, 30):
+            string = 'E'+str(i)
+            self.commandparser('M244', 'C0', string)
+            self.commandparser('M244', 'C1', string)
+            self.commandparser('M244', 'C2', string)
+
+    def test_i2c_cart0(self):
+        logging.info("Testing Cartridge 0 I2C")
+        for i in range(0, 30):
+            string = 'E'+str(i)
+            self.commandparser('M244', 'C0', string)
+
+    def test_i2c_cart1(self):
+        logging.info("Testing Cartridge 1 I2C")
+        for i in range(0, 30):
+            string = 'E'+str(i)
+            self.commandparser('M244', 'C1', string)
+
+    def test_i2c_cartridgeHolder(self):
+        logging.info("Testing Cartridge Holder I2C")
+        for i in range(0, 30):
+            string = 'E'+str(i)
+            self.commandparser('M244', 'C2', string)
+
+    def test_cart1_info(self):
+        cart0status = self.commandparser('M245', 'C0')
+        self.parseCartridgeStatus(cart0status, "Cartridge 0")
+
+    def test_cart2_info(self):
+        cart1status = self.commandparser('M245', 'C1')
+        self.parseCartridgeStatus(cart1status, "Cartridge 1")
+
+    def test_cartridgeholder(self):
+        cartridgeHolderStatus = self.commandparser('M245', 'C2')
+        self.parseCartridgeStatus(cartridgeHolderStatus, "Cartridge Holder")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
![logo](https://cloud.githubusercontent.com/assets/12700993/15369692/c1ffed68-1d01-11e6-9bfa-05f534787e32.gif)

**Caution! This will cause any printers running SMC regulators to have poor pressure configuration.**
## Metalworks E-Regulator Setting

## Description
This branch involves changes to the regulator.h to correspond with data taken from Metworks Electropneumatic Regulators. This also improves pressure setting in regulator.cpp, so that desired_pressure will not change depending on hysteresis values.

### Requirements
- [X] Unit Test
- [X] Alignment run successfully
- [x] Approval 1 DT
- [X] Approval 2 RR