### PR TITLE
St/refactor m236 multiplier

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4567,7 +4567,7 @@ inline void gcode_M221() {
       SERIAL_PROTOCOLLN(extruder_multiplier[target_extruder]);
     }
     else {
-      SERIAL_PROTOCOL(int(code_value()));
+      SERIAL_PROTOCOL(int(active_extruder));
       SERIAL_PROTOCOLPGM("): ");
       SERIAL_PROTOCOLLN(extruder_multiplier[active_extruder]);
     }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4699,7 +4699,7 @@ inline void gcode_M226() {
     }
     // Desired pressure value given
     if(code_seen('S')) {
-      float psi = code_value();
+      float psi = code_value() * (extruder_multiplier[active_extruder] / 100.0);
       // Desired pressure outside allowed range?
       if((psi > OUTPUT_PSI_MAX) || (psi < OUTPUT_PSI_MIN)) {
         SERIAL_PROTOCOLPGM("ERROR: Desired Pressure Outside Allowed Pressure Range (");


### PR DESCRIPTION
###### 
![multiplier-effect](https://cloud.githubusercontent.com/assets/16328681/15411076/7c54039a-1deb-11e6-8db4-b1b492f1291c.png)

# M236 Multiplier

This change adds a pressure multiplier to the `M236` command, taken from the currently unused tool1 extrusion multiplier in the case of typical FFF/silver printing... it actually applies the active tool's multiplier regardless of tool type, but FFF printing will not be affected as it sends no pressure change commands.

This feature is compatible with dual pneumatics but will need to be fixed when an AugerTool is eventually implemented in Euclid, as that will still make conventional use of the extrusion multiplier but will need to set and maintain its own specified pressure.

I'd like to make one quick change in Euclid to ensure that this change is applied to the very next polygon or point deposition (regardless of whether or not Euclid determines that a pressure change is actually needed), but whether this could cause issues with buffered tool changes remains to be seen... for now the scaling factor will only take effect on the next pressure change but I will try to investigate a robust improvement for this soon... may require aborting the current buffer, inserting an `M236` command, then continuing on with the rest of the buffer.

Also noticed a minor typo that I made when adding display functionality to `M221`, decided to just fix that up here.

(Tested on Bran, no issues)