### PR TITLE
Dt/enhancement addition i2c commands from peripherals

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -394,7 +394,7 @@ Here are some standard links for getting your machine calibrated:
  // 1 - Built-in Pressure Transducer (ITV0050-2UL)
  // 2 - Built-in Pressure Transducer (Regtronics M5)
 
-  #define E_REGULATOR_SENSOR 1
+  #define E_REGULATOR_SENSOR 2
   #define DAC_I2C
  // 130 psi is max settable pressure for e-regulator
   #define OUTPUT_PSI_MAX     130.0 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -394,7 +394,7 @@ Here are some standard links for getting your machine calibrated:
  // 1 - Built-in Pressure Transducer (ITV0050-2UL)
  // 2 - Built-in Pressure Transducer (Regtronics M5)
 
-  #define E_REGULATOR_SENSOR 2
+  #define E_REGULATOR_SENSOR 1
   #define DAC_I2C
  // 130 psi is max settable pressure for e-regulator
   #define OUTPUT_PSI_MAX     130.0 

--- a/Marlin/GCodes.h
+++ b/Marlin/GCodes.h
@@ -36,6 +36,7 @@
  * "M" Codes
  *
  * M251 - Queries small pneumatics cartridge to retrieve Syringe status
+ * M252 - Clear error state on I2C peripherals (cartridges and holder)
  * M253 - Queries cartridge to see if 24 volts are present or not.
           FFF: Returns whether hot end is active
           Pneumatics: Returns whether solenoid is active
@@ -51,6 +52,37 @@
 * M251: I2C Query Syringe Status, currently only valid for Cart 1
 */
 inline void gcode_M251() { I2C__GetGpioSwitch(CART1_ADDR); }
+
+/*
+* M252 - Clear error state on I2C peripherals (cartridges and holder)
+*   C - 0 - 2   0 = FFF 1 = Pneumatics 2 = Cartridge Holder
+*/
+inline void gcode_M252() {
+  uint8_t i2c_address = 0xFF;
+
+  // Desired address for peripheral device
+  if (code_seen('C')) {
+    switch (int(code_value())) {
+      case 0:
+        i2c_address = CART0_ADDR;
+        break;
+      case 1:
+        i2c_address = CART1_ADDR;
+        break;
+      case 2:
+        i2c_address = CART_HOLDER_ADDR;
+        break;
+      default:
+        SERIAL_ECHOLNPGM("Invalid Address");
+        return;
+    }
+  } else {
+    SERIAL_ECHOLNPGM("No cartridge address given");
+    return;
+  }
+
+  I2C__ClearError(i2c_address);
+}
 
 /*
 * M253: I2C Query Vsense, currently only valid for cartridges

--- a/Marlin/GCodes.h
+++ b/Marlin/GCodes.h
@@ -36,8 +36,10 @@
  *
  * "M" Codes
  *
- * M251 - Queries small pneumatics cartridge to retrieve solenoid status
- * M253 - Queries cartridge to see if 24 volts are present or not
+ * M251 - Queries small pneumatics cartridge to retrieve Syringe status
+ * M253 - Queries cartridge to see if 24 volts are present or not.
+          FFF: Returns whether hot end is active
+          Pneumatics: Returns whether solenoid is active
  * M272 - Set axis steps-per-unit for one or more axes, X, Y, Z, and E using
  *        the default ball-bar units
 */
@@ -48,8 +50,7 @@
 
 
 /*
-* M251: I2C Query Solenoid Status, currently only valid for Cart 1
-*   C - 0 - 1   Cartridge Address (0 or 1)
+* M251: I2C Query Syringe Status, currently only valid for Cart 1
 */
 inline void gcode_M251() { 
   I2C__GetGpioSwitch(CART1_ADDR); 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6628,7 +6628,7 @@ void process_next_command() {
         gcode_M249();
         break;
 
-      case 251: // I2C Query Solenoid Status:
+      case 251: // I2C Query Syringe Status:
         gcode_M251();
         break;
       case 253: // I2C Query Voltage Sense:

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5087,37 +5087,6 @@ inline void gcode_M249() {
   }
 }
 
-
-
-inline void gcode_M252() {
-  uint8_t i2c_address = 0xFF;
-  // Used to see if we've been given arguments, and to warn you through the
-  // serial port if they're not seen.
-  bool hasC;
-
-  // Desired address for peripheral device
-  if (hasC = code_seen('C')) {
-    switch(int(code_value())) {
-      case 0:
-        i2c_address = CART0_ADDR;
-        break;
-      case 1:
-        i2c_address = CART1_ADDR;
-        break;
-      case 2:
-        i2c_address = CART_HOLDER_ADDR;
-        break;
-    }
-  }
-  
-  if (!hasC){
-    SERIAL_ECHOLNPGM("No cartridge address given");
-    return;
-  }
-
-  I2C__ClearError(i2c_address);
-}
-
 #if HAS_SERVOS
 
   /**

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5087,6 +5087,8 @@ inline void gcode_M249() {
   }
 }
 
+
+
 inline void gcode_M252() {
   uint8_t i2c_address = 0xFF;
   // Used to see if we've been given arguments, and to warn you through the
@@ -6626,6 +6628,13 @@ void process_next_command() {
         gcode_M249();
         break;
 
+      case 251: // I2C Query Solenoid Status:
+        gcode_M251();
+        break;
+      case 253: // I2C Query Voltage Sense:
+        gcode_M253();
+        break;
+        
       case 272:
         gcode_M272();
         break;

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4896,6 +4896,9 @@ inline void gcode_M243() {
       case 2:
         i2c_address = CART_HOLDER_ADDR;
         break;
+      default:
+        SERIAL_ECHOLNPGM("Invalid Address");
+        return;
     }
   }
   // Desired EEPROM address
@@ -4951,6 +4954,9 @@ inline void gcode_M244() {
       case 2:
         i2c_address = CART_HOLDER_ADDR;
         break;
+      default:
+        SERIAL_ECHOLNPGM("Invalid Address");
+        return;
     }
   }
   // Desired EEPROM address
@@ -4994,6 +5000,9 @@ inline void gcode_M245() {
       case 2:
         i2c_address = CART_HOLDER_ADDR;
         break;
+      default:
+        SERIAL_ECHOLNPGM("Invalid Address");
+        return;
     }
   }
   
@@ -5051,6 +5060,9 @@ inline void gcode_M248() {
       case 1:
         Cartridge__SetPresentCheck(true);
         break;
+      default:
+        SERIAL_ECHOLNPGM("(E1) or (E0) not given");
+        return;
     }
   }
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5013,7 +5013,7 @@ inline void gcode_M245() {
 
   I2C__GetSerial(i2c_address);
   I2C__GetProgrammerStation(i2c_address);
-  I2C__GetCartridgeType(i2c_address);
+  I2C__GetPeripheralType(i2c_address);
   I2C__GetSize(i2c_address);
   I2C__GetMaterial(i2c_address);
   I2C__GetFirmwareVersion(i2c_address);

--- a/Marlin/Voxel8_I2C_Commands.cpp
+++ b/Marlin/Voxel8_I2C_Commands.cpp
@@ -16,20 +16,20 @@
 //===========================================================================
 
 // General Defines
-#define BYTE_SIZE                           (8)
+#define BYTE_SIZE (8)
 
 // Defines for specific commands
 
 // 127 (50%) is maxy duty cycle for 12V fans wired in parallel. 255 should be
 // fine for those wired in series (Gen 3D, and beyond).
-#define MAX_FAN_DUTY                        (255)
+#define MAX_FAN_DUTY (255)
 
 // Defines for use with requesting serial number from Cartridges
-#define CARTRIDGE_SERIAL_LENGTH             (4)
+#define CARTRIDGE_SERIAL_LENGTH (4)
 #define CARTRIDGE_SERIAL_PROGRAMMER_STATION (0)
-#define CARTRIDGE_SERIAL_TYPE               (1)
-#define CARTRIDGE_SERIAL_NUMBER_0           (2)
-#define CARTRIDGE_SERIAL_NUMBER_1           (3)
+#define CARTRIDGE_SERIAL_TYPE (1)
+#define CARTRIDGE_SERIAL_NUMBER_0 (2)
+#define CARTRIDGE_SERIAL_NUMBER_1 (3)
 //===========================================================================
 //============================ Private Variables ============================
 //===========================================================================
@@ -37,10 +37,8 @@
 //===========================================================================
 //====================== Private Functions Prototypes =======================
 //===========================================================================
-void writeThreeBytePacket(uint8_t I2C_target_address,
-                          uint8_t command,
-                          uint8_t address,
-                          uint8_t data);
+void writeThreeBytePacket(uint8_t I2C_target_address, uint8_t command,
+                          uint8_t address, uint8_t data);
 
 void requestAndPrintPacket(uint8_t I2C_target_address, uint8_t bytes);
 
@@ -286,6 +284,35 @@ void I2C__GetFirmwareVersion(uint8_t cartridge) {
   writeThreeBytePacket(cartridge, EEPROM_READ_FRMWRE, I2C_EMPTY_ADDRESS,
                        I2C_EMPTY_DATA);
   SERIAL_PROTOCOLPGM("Cartridge Firmware Version = ");
+  // Read from cartridge and report
+  requestAndPrintPacket(cartridge, 1);
+  SERIAL_EOL;
+}
+
+/**
+ * Read the voltage sense pin on a cartridge and print it on the serial port
+ * @parameter cartridge           Address of the target (cartridge)
+ */
+void I2C__GetVoltageSense(uint8_t cartridge) {
+  // Send message
+  writeThreeBytePacket(cartridge, GET_GPIO_V_SENSE, I2C_EMPTY_ADDRESS,
+                       I2C_EMPTY_DATA);
+  SERIAL_PROTOCOLPGM("V Sense = ");
+  // Read from cartridge and report
+  requestAndPrintPacket(cartridge, 1);
+  SERIAL_EOL;
+}
+
+/**
+ * Read the SYRINGE_ACTIVE pin on a pneumatics cartridge and print it on the
+ * serial port
+ * @parameter cartridge           Address of the target (pneumatic cartridge)
+ */
+void I2C__GetGpioSwitch(uint8_t cartridge) {
+  // Send message
+  writeThreeBytePacket(cartridge, GET_GPIO_SWITCH, I2C_EMPTY_ADDRESS,
+                       I2C_EMPTY_DATA);
+  SERIAL_PROTOCOLPGM("Solenoid Sense = ");
   // Read from cartridge and report
   requestAndPrintPacket(cartridge, 1);
   SERIAL_EOL;

--- a/Marlin/Voxel8_I2C_Commands.cpp
+++ b/Marlin/Voxel8_I2C_Commands.cpp
@@ -80,7 +80,7 @@ void I2C__GeneralCommand(uint8_t I2C_target_address, uint8_t command,
 }
 
 /**
- * Sets the speed of the fan on the cartridge holder.
+ * Sets the speed of the fan on the cartrdge holder.
  * @param fanspeed            Speed the fan is set to
  */
 void I2C__SetFanDrive0PWM(uint8_t fanSpeed) {
@@ -138,14 +138,14 @@ void I2C__ToggleUV(uint8_t data) {
 }
 
 /**
- * Writes data to a specific EEPROM address on a cartridge
- * @param cartridge           Address of the target (cartridge)
+ * Writes data to a specific EEPROM address on a I2C_target_address
+ * @param I2C_target_address  Address of the target (cartridge or holder)
  * @param address             The EEPROM address being written to
  * @param data                The data being written
  */
-void I2C__EEPROMWrite(uint8_t cartridge, uint8_t eeprom_address, uint8_t data) {
+void I2C__EEPROMWrite(uint8_t I2C_target_address, uint8_t eeprom_address, uint8_t data) {
   // Send message
-  writeThreeBytePacket(cartridge, EEPROM_WRITE, eeprom_address, data);
+  writeThreeBytePacket(I2C_target_address, EEPROM_WRITE, eeprom_address, data);
 
   // Send information to Octoprint
   SERIAL_PROTOCOLLNPGM("Command: 'EEPROM Write' Sent");
@@ -154,139 +154,139 @@ void I2C__EEPROMWrite(uint8_t cartridge, uint8_t eeprom_address, uint8_t data) {
   SERIAL_PROTOCOLPGM("Address = ");
   SERIAL_PROTOCOL(eeprom_address);
 
-  // Read from cartridge and report
-  requestAndPrintPacket(cartridge, 1);
+  // Read from I2C_target_address and report
+  requestAndPrintPacket(I2C_target_address, 1);
   SERIAL_EOL;
 }
 
 /**
- * Reads data from a specific EEPROM address on a cartridge
- * @param cartridge           Address of the target (cartridge)
+ * Reads data from a specific EEPROM address on a I2C_target_address
+ * @param I2C_target_address  Address of the target (cartridge or holder)
  * @param address             The EEPROM address being written to
  */
-void I2C__EEPROMRead(uint8_t cartridge, uint8_t address) {
+void I2C__EEPROMRead(uint8_t I2C_target_address, uint8_t address) {
   // Send message
-  writeThreeBytePacket(cartridge, EEPROM_READ, address, I2C_EMPTY_DATA);
+  writeThreeBytePacket(I2C_target_address, EEPROM_READ, address, I2C_EMPTY_DATA);
 
   // Send information to Octoprint
   SERIAL_PROTOCOLLNPGM("Command: 'EEPROM READ' Sent");
   SERIAL_PROTOCOLPGM("Value = ");
 
-  // Read from cartridge and report
-  requestAndPrintPacket(cartridge, 1);
+  // Read from I2C_target_address and report
+  requestAndPrintPacket(I2C_target_address, 1);
   SERIAL_EOL;
 }
 
 /**
- * Read the serial number from a cartridge and print it on the serial port
- * @param cartridge           Address of the target (cartridge)
+ * Read the serial number from a I2C_target_address and print it on the serial port
+ * @param I2C_target_address           Address of the target (cartridge or holder)
  */
-void I2C__GetSerial(uint8_t cartridge) {
+void I2C__GetSerial(uint8_t I2C_target_address) {
   // Send message
-  writeThreeBytePacket(cartridge, EEPROM_READ_SERIAL, I2C_EMPTY_ADDRESS,
+  writeThreeBytePacket(I2C_target_address, EEPROM_READ_SERIAL, I2C_EMPTY_ADDRESS,
                        I2C_EMPTY_DATA);
 
   // Send information to Octoprint
   SERIAL_PROTOCOLPGM("Serial Number = ");
 
-  // Read from cartridge and report
-  requestAndPrintSerial(cartridge);
+  // Read from I2C_target_address and report
+  requestAndPrintSerial(I2C_target_address);
   SERIAL_EOL;
 }
 
 /**
  * Read the number of the programmer used on a cartridge and print it on
  * the serial port
- * @param cartridge           Address of the target (cartridge)
+ * @param I2C_target_address           Address of the target (cartridge)
  */
-void I2C__GetProgrammerStation(uint8_t cartridge) {
+void I2C__GetProgrammerStation(uint8_t I2C_target_address) {
   // Send message
-  writeThreeBytePacket(cartridge, EEPROM_READ_PRGMR, I2C_EMPTY_ADDRESS,
+  writeThreeBytePacket(I2C_target_address, EEPROM_READ_PRGMR, I2C_EMPTY_ADDRESS,
                        I2C_EMPTY_DATA);
 
   // Send information to Octoprint
   SERIAL_PROTOCOLPGM("Programmer Station = ");
 
-  // Read from cartridge and report
-  requestAndPrintPacket(cartridge, 1);
+  // Read from I2C_target_address and report
+  requestAndPrintPacket(I2C_target_address, 1);
   SERIAL_EOL;
 }
 
 /**
- * Read the variety of cartridge and print it on the serial port
- * @param cartridge           Address of the target (cartridge)
+ * Read the variety of peripheral and print it on the serial port
+ * @param I2C_target_address           Address of the target (cartridge or holder)
  */
-void I2C__GetCartridgeType(uint8_t cartridge) {
+void I2C__GetPeripheralType(uint8_t I2C_target_address) {
   // Send message
-  writeThreeBytePacket(cartridge, EEPROM_READ_TYPE, I2C_EMPTY_ADDRESS,
+  writeThreeBytePacket(I2C_target_address, EEPROM_READ_TYPE, I2C_EMPTY_ADDRESS,
                        I2C_EMPTY_DATA);
 
   // Send information to Octoprint
-  SERIAL_PROTOCOLPGM("Cartridge Type = ");
+  SERIAL_PROTOCOLPGM("I2C_target_address Type = ");
 
-  // Read from cartridge and report
-  requestAndPrintPacket(cartridge, 1);
+  // Read from I2C_target_address and report
+  requestAndPrintPacket(I2C_target_address, 1);
   SERIAL_EOL;
 }
 
 /**
  * Read the size of the nozzle from cartridge and print it on the serial port
- * @param cartridge           Address of the target (cartridge)
+ * @param I2C_target_address           Address of the target (cartridge)
  */
-void I2C__GetSize(uint8_t cartridge) {
+void I2C__GetSize(uint8_t I2C_target_address) {
   // Send message
-  writeThreeBytePacket(cartridge, EEPROM_READ_SIZE, I2C_EMPTY_ADDRESS,
+  writeThreeBytePacket(I2C_target_address, EEPROM_READ_SIZE, I2C_EMPTY_ADDRESS,
                        I2C_EMPTY_DATA);
 
   // Send information to Octoprint
   SERIAL_PROTOCOLPGM("Cartridge Size = ");
 
-  // Read from cartridge and report
-  requestAndPrintPacket(cartridge, 1);
+  // Read from I2C_target_address and report
+  requestAndPrintPacket(I2C_target_address, 1);
   SERIAL_EOL;
 }
 
 /**
  * Read the material contained by a cartridge and print it on the serial port
- * @param cartridge           Address of the target (cartridge)
+ * @param I2C_target_address           Address of the target (cartridge)
  */
-void I2C__GetMaterial(uint8_t cartridge) {
+void I2C__GetMaterial(uint8_t I2C_target_address) {
   // Send message
-  writeThreeBytePacket(cartridge, EEPROM_READ_MTRL, I2C_EMPTY_ADDRESS,
+  writeThreeBytePacket(I2C_target_address, EEPROM_READ_MTRL, I2C_EMPTY_ADDRESS,
                        I2C_EMPTY_DATA);
 
   // Send information to Octoprint
   SERIAL_PROTOCOLPGM("Cartridge Material = ");
 
-  // Read from cartridge and report
-  requestAndPrintPacket(cartridge, 1);
+  // Read from I2C_target_address and report
+  requestAndPrintPacket(I2C_target_address, 1);
   SERIAL_EOL;
 }
 
 /**
- * Read the material contained by a cartridge and print it on the serial port
- * @param cartridge           Address of the target (cartridge)
+ * Read the error code of an I2C_target_address and print it on the serial port
+ * @param I2C_target_address     Address of the target (cartridge or holder)
  */
-void I2C__GetErrorCode(uint8_t cartridge) {
+void I2C__GetErrorCode(uint8_t I2C_target_address) {
   // Send message
-  writeThreeBytePacket(cartridge, EEPROM_READ_ERR, I2C_EMPTY_ADDRESS,
+  writeThreeBytePacket(I2C_target_address, EEPROM_READ_ERR, I2C_EMPTY_ADDRESS,
                        I2C_EMPTY_DATA);
 
-  // Read from cartridge and report
-  requestAndPrintPacket(cartridge, 1);
+  // Read from I2C_target_address and report
+  requestAndPrintPacket(I2C_target_address, 1);
 }
 
 /**
- * Read the firmware version by a cartridge and print it on the serial port
- * @param cartridge           Address of the target (cartridge)
+ * Read the firmware version by a I2C_target_address and print it on the serial port
+ * @param I2C_target_address     Address of the target (cartridge or holder)
  */
-void I2C__GetFirmwareVersion(uint8_t cartridge) {
+void I2C__GetFirmwareVersion(uint8_t I2C_target_address) {
   // Send message
-  writeThreeBytePacket(cartridge, EEPROM_READ_FRMWRE, I2C_EMPTY_ADDRESS,
+  writeThreeBytePacket(I2C_target_address, EEPROM_READ_FRMWRE, I2C_EMPTY_ADDRESS,
                        I2C_EMPTY_DATA);
   SERIAL_PROTOCOLPGM("Cartridge Firmware Version = ");
-  // Read from cartridge and report
-  requestAndPrintPacket(cartridge, 1);
+  // Read from I2C_target_address and report
+  requestAndPrintPacket(I2C_target_address, 1);
   SERIAL_EOL;
 }
 
@@ -294,23 +294,23 @@ void I2C__GetFirmwareVersion(uint8_t cartridge) {
  * Read the voltage sense pin on a cartridge and print it on the serial port.
  * On the pneumatics cartridge, this should correspond to the solenoid being 
  * active. For FFF, this represents if the hot end is active.
- * @parameter cartridge           Address of the target (cartridge)
+ * @parameter I2C_target_address           Address of the target (cartridge)
  */
-void I2C__GetVoltageSense(uint8_t cartridge) {
-    if ((cartridge != CART0_ADDR) && (cartridge != CART1_ADDR)) {
+void I2C__GetVoltageSense(uint8_t I2C_target_address) {
+    if ((I2C_target_address != CART0_ADDR) && (I2C_target_address != CART1_ADDR)) {
     return;
   }
   // Send message
-  writeThreeBytePacket(cartridge, GET_GPIO_V_SENSE, I2C_EMPTY_ADDRESS,
+  writeThreeBytePacket(I2C_target_address, GET_GPIO_V_SENSE, I2C_EMPTY_ADDRESS,
                        I2C_EMPTY_DATA);
-  if (cartridge == CART0_ADDR) {
+  if (I2C_target_address == CART0_ADDR) {
     SERIAL_PROTOCOLPGM("Extruder Status = ");
   }
-  else if (cartridge == CART1_ADDR) {
+  else if (I2C_target_address == CART1_ADDR) {
     SERIAL_PROTOCOLPGM("Solenoid Status = ");
   }
-  // Read from cartridge and report
-  requestAndPrintPacket(cartridge, 1);
+  // Read from I2C_target_address and report
+  requestAndPrintPacket(I2C_target_address, 1);
   SERIAL_EOL;
 }
 
@@ -318,28 +318,28 @@ void I2C__GetVoltageSense(uint8_t cartridge) {
  * Read the SYRINGE_ACTIVE pin on a pneumatics cartridge and print it on the
  * serial port. This should be a 1 when the syringe is deployed, and a 0 when
  * it's retracted. 
- * @parameter cartridge           Address of the target (pneumatic cartridge)
+ * @parameter I2C_target_address           Address of the target (pneumatic cartridge)
  */
-void I2C__GetGpioSwitch(uint8_t cartridge) {
-  if (cartridge != CART1_ADDR){
+void I2C__GetGpioSwitch(uint8_t I2C_target_address) {
+  if (I2C_target_address != CART1_ADDR){
     return;
   }
   // Send message
-  writeThreeBytePacket(cartridge, GET_GPIO_SWITCH, I2C_EMPTY_ADDRESS,
+  writeThreeBytePacket(I2C_target_address, GET_GPIO_SWITCH, I2C_EMPTY_ADDRESS,
                        I2C_EMPTY_DATA);
   SERIAL_PROTOCOLPGM("Syringe Status = ");
-  // Read from cartridge and report
-  requestAndPrintPacket(cartridge, 1);
+  // Read from I2C_target_address and report
+  requestAndPrintPacket(I2C_target_address, 1);
   SERIAL_EOL;
 }
 
 /**
- * Clear the error flag for a particular cartridge if it's set
- * @param cartridge           Address of the target (cartridge)
+ * Clear the error flag for a particular I2C_target_address if it's set
+ * @param I2C_target_address           Address of the target (I2C_target_address)
  */
-void I2C__ClearError(uint8_t cartridge) {
+void I2C__ClearError(uint8_t I2C_target_address) {
   // Send message
-  writeThreeBytePacket(cartridge, CLEAR_ERROR, I2C_EMPTY_ADDRESS,
+  writeThreeBytePacket(I2C_target_address, CLEAR_ERROR, I2C_EMPTY_ADDRESS,
                        I2C_EMPTY_DATA);
   SERIAL_PROTOCOLPGM("Cleared Error State");
   SERIAL_EOL;
@@ -367,7 +367,7 @@ void writeThreeBytePacket(uint8_t I2C_target_address, uint8_t command,
 }
 
 void requestAndPrintPacket(uint8_t I2C_target_address, uint8_t bytes) {
-  // Read from cartridge and report
+  // Read from I2C_target_address and report
   Wire.requestFrom(I2C_target_address, bytes);
   if (!Wire.available()) {
     SERIAL_PROTOCOLPGM(" No Packet Available ");

--- a/Marlin/Voxel8_I2C_Commands.cpp
+++ b/Marlin/Voxel8_I2C_Commands.cpp
@@ -290,14 +290,21 @@ void I2C__GetFirmwareVersion(uint8_t cartridge) {
 }
 
 /**
- * Read the voltage sense pin on a cartridge and print it on the serial port
+ * Read the voltage sense pin on a cartridge and print it on the serial port.
+ * On the pneumatics cartridge, this should correspond to the solenoid being 
+ * active. For FFF, this represents if the hot end is active.
  * @parameter cartridge           Address of the target (cartridge)
  */
 void I2C__GetVoltageSense(uint8_t cartridge) {
   // Send message
   writeThreeBytePacket(cartridge, GET_GPIO_V_SENSE, I2C_EMPTY_ADDRESS,
                        I2C_EMPTY_DATA);
-  SERIAL_PROTOCOLPGM("V Sense = ");
+  if (cartridge == CART0_ADDR) {
+    SERIAL_PROTOCOLPGM("Extruder Status = ");
+  }
+  else if (cartridge == CART1_ADDR) {
+    SERIAL_PROTOCOLPGM("Solenoid Status = ");
+  }
   // Read from cartridge and report
   requestAndPrintPacket(cartridge, 1);
   SERIAL_EOL;
@@ -305,14 +312,15 @@ void I2C__GetVoltageSense(uint8_t cartridge) {
 
 /**
  * Read the SYRINGE_ACTIVE pin on a pneumatics cartridge and print it on the
- * serial port
+ * serial port. This should be a 1 when the syringe is deployed, and a 0 when
+ * it's retracted. 
  * @parameter cartridge           Address of the target (pneumatic cartridge)
  */
 void I2C__GetGpioSwitch(uint8_t cartridge) {
   // Send message
   writeThreeBytePacket(cartridge, GET_GPIO_SWITCH, I2C_EMPTY_ADDRESS,
                        I2C_EMPTY_DATA);
-  SERIAL_PROTOCOLPGM("Solenoid Sense = ");
+  SERIAL_PROTOCOLPGM("Syringe Status = ");
   // Read from cartridge and report
   requestAndPrintPacket(cartridge, 1);
   SERIAL_EOL;

--- a/Marlin/Voxel8_I2C_Commands.cpp
+++ b/Marlin/Voxel8_I2C_Commands.cpp
@@ -30,6 +30,7 @@
 #define CARTRIDGE_SERIAL_TYPE (1)
 #define CARTRIDGE_SERIAL_NUMBER_0 (2)
 #define CARTRIDGE_SERIAL_NUMBER_1 (3)
+
 //===========================================================================
 //============================ Private Variables ============================
 //===========================================================================
@@ -296,6 +297,9 @@ void I2C__GetFirmwareVersion(uint8_t cartridge) {
  * @parameter cartridge           Address of the target (cartridge)
  */
 void I2C__GetVoltageSense(uint8_t cartridge) {
+    if ((cartridge != CART0_ADDR) && (cartridge != CART1_ADDR)) {
+    return;
+  }
   // Send message
   writeThreeBytePacket(cartridge, GET_GPIO_V_SENSE, I2C_EMPTY_ADDRESS,
                        I2C_EMPTY_DATA);
@@ -317,6 +321,9 @@ void I2C__GetVoltageSense(uint8_t cartridge) {
  * @parameter cartridge           Address of the target (pneumatic cartridge)
  */
 void I2C__GetGpioSwitch(uint8_t cartridge) {
+  if (cartridge != CART1_ADDR){
+    return;
+  }
   // Send message
   writeThreeBytePacket(cartridge, GET_GPIO_SWITCH, I2C_EMPTY_ADDRESS,
                        I2C_EMPTY_DATA);

--- a/Marlin/Voxel8_I2C_Commands.h
+++ b/Marlin/Voxel8_I2C_Commands.h
@@ -42,12 +42,12 @@
 #define EEPROM_READ_ERR         0x13
 #define EEPROM_READ_FRMWRE      0x14
 
-#define GET_GPIO_V_SENSE        0x20
-#define GET_GPIO_SWITCH         0x21
-
 #define CLEAR_ERROR             0x15
 
 #define EEPROM_READ_TEMP        0x16
+
+#define GET_GPIO_V_SENSE        0x20
+#define GET_GPIO_SWITCH         0x21
 
 //===========================================================================
 //============================= Public Functions ============================

--- a/Marlin/Voxel8_I2C_Commands.h
+++ b/Marlin/Voxel8_I2C_Commands.h
@@ -54,107 +54,110 @@
 //===========================================================================
 /**
  * Sends a general I2C Command.
- * @parameter I2C_target_address  Address of the target (cartridge or 
+ * @param I2C_target_address  Address of the target (cartridge or
  *                                cartridge holder)
- * @parameter command             The command being sent
- * @parameter address             The EEPROM address, if applicable
- * @parameter data                The data used for the command
- */ 
+ * @param command             The command being sent
+ * @param address             The EEPROM address, if applicable
+ * @param data                The data used for the command
+ */
 void I2C__GeneralCommand(uint8_t I2C_target_address, uint8_t command,
                          uint8_t address, uint8_t data);
 
 /**
- * Sets the speed of the fan on the cartridge holder.
- * @parameter fanspeed            Speed the fan is set to
- */ 
+ * Sets the speed of the fan on the cartrdge holder.
+ * @param fanspeed            Speed the fan is set to
+ */
 void I2C__SetFanDrive0PWM(uint8_t fanSpeed);
 
 /**
  * Turns off the fan on the cartridge holder.
- */ 
+ */
 void I2C__SetFanOff(void);
 
 /**
  * Toggles the UV LED
- * @parameter data                0 to disable, enabled on call otherwise
+ * @param data                0 to disable, enabled on call otherwise
  */
 void I2C__ToggleUV(uint8_t data);
 
 /**
- * Writes data to a specific EEPROM address on a cartridge
- * @parameter cartridge           Address of the target
- * @parameter address             The EEPROM address being written to
- * @parameter data                The data being written
+ * Writes data to a specific EEPROM address on a I2C_target_address
+ * @param I2C_target_address  Address of the target (cartridge or holder)
+ * @param address             The EEPROM address being written to
+ * @param data                The data being written
  */
-void I2C__EEPROMWrite(uint8_t cartridge, uint8_t eeprom_address, uint8_t data);
+void I2C__EEPROMWrite(uint8_t I2C_target_address, uint8_t eeprom_address, uint8_t data);
 
 /**
- * Reads data from a specific EEPROM address on a cartridge
- * @parameter cartridge           Address of the target
- * @parameter address             The EEPROM address being written to
- */ 
-void I2C__EEPROMRead(uint8_t cartridge, uint8_t address);
+ * Reads data from a specific EEPROM address on a I2C_target_address
+ * @param I2C_target_address  Address of the target (cartridge or holder)
+ * @param address             The EEPROM address being written to
+ */
+void I2C__EEPROMRead(uint8_t I2C_target_address, uint8_t address);
 
 /**
- * Read the serial number from a cartridge and print it on the serial port
- * @parameter cartridge           Address of the target
- */ 
-void I2C__GetSerial(uint8_t cartridge);
+ * Read the serial number from a I2C_target_address and print it on the serial port
+ * @param I2C_target_address  Address of the target (cartridge or holder)
+ */
+void I2C__GetSerial(uint8_t I2C_target_address);
 
 /**
  * Read the number of the programmer used on a cartridge and print it on
  * the serial port
- * @parameter cartridge           Address of the target
- */ 
-void I2C__GetProgrammerStation(uint8_t cartridge);
+ * @param I2C_target_address           Address of the target (cartridge)
+ */
+void I2C__GetProgrammerStation(uint8_t I2C_target_address);
 
 /**
- * Read the variety of cartridge and print it on the serial port
- * @parameter cartridge           Address of the target
- */ 
-void I2C__GetCartridgeType(uint8_t cartridge);
+ * Read the variety of peripheral and print it on the serial port
+ * @param I2C_target_address           Address of the target (cartridge or holder)
+ */
+void I2C__GetPeripheralType(uint8_t I2C_target_address);
 
 /**
  * Read the size of the nozzle from cartridge and print it on the serial port
- * @parameter cartridge           Address of the target
+ * @param I2C_target_address           Address of the target (cartridge)
  */ 
-void I2C__GetSize(uint8_t cartridge);
+void I2C__GetSize(uint8_t I2C_target_address);
 
 /**
  * Read the material contained by a cartridge and print it on the serial port
- * @parameter cartridge           Address of the target
- */ 
-void I2C__GetMaterial(uint8_t cartridge);
+ * @param I2C_target_address           Address of the target (cartridge)
+ */
+void I2C__GetMaterial(uint8_t I2C_target_address);
 
 /**
- * Read the material contained by a cartridge and print it on the serial port
- * @parameter cartridge           Address of the target
- */ 
-void I2C__GetErrorCode(uint8_t cartridge);
+ * Read the error code of an I2C_target_address and print it on the serial port
+ * @param I2C_target_address     Address of the target (cartridge or holder)
+ */
+void I2C__GetErrorCode(uint8_t I2C_target_address);
 
 /**
- * Read the firmware version by a cartridge and print it on the serial port
- * @parameter cartridge           Address of the target
- */ 
-void I2C__GetFirmwareVersion(uint8_t cartridge);
+ * Read the firmware version by a I2C_target_address and print it on the serial port
+ * @param I2C_target_address     Address of the target (cartridge or holder)
+ */
+void I2C__GetFirmwareVersion(uint8_t I2C_target_address);
 
 /**
- * Read the voltage sense pin on a cartridge and print it on the serial port
- * @parameter cartridge           Address of the target (cartridge)
- */ 
-void I2C__GetVoltageSense(uint8_t cartridge);
+ * Read the voltage sense pin on a cartridge and print it on the serial port.
+ * On the pneumatics cartridge, this should correspond to the solenoid being 
+ * active. For FFF, this represents if the hot end is active.
+ * @param I2C_target_address           Address of the target (cartridge)
+ */
+void I2C__GetVoltageSense(uint8_t I2C_target_address);
 
 /**
- * Read the SYRINGE_ACTIVE pin on a pneumatics cartridge and print it on the 
- * serial port
- * @parameter cartridge           Address of the target (pneumatic cartridge)
- */ 
-void I2C__GetGpioSwitch(uint8_t cartridge);
+ * Read the SYRINGE_ACTIVE pin on a pneumatics cartridge and print it on the
+ * serial port. This should be a 1 when the syringe is deployed, and a 0 when
+ * it's retracted. 
+ * @param I2C_target_address           Address of the target (pneumatic cartridge)
+ */
+void I2C__GetGpioSwitch(uint8_t I2C_target_address);
 
 /**
- * Clear the error flag for a particular cartridge if it's set
- * @parameter cartridge           Address of the target
- */ 
-void I2C__ClearError(uint8_t cartridge);
+ * Clear the error flag for a particular I2C_target_address if it's set
+ * @param I2C_target_address           Address of the target (I2C_target_address)
+ */
+void I2C__ClearError(uint8_t I2C_target_address);
 
 #endif  // MARLIN_VOXEL8_I2C_COMMANDS_H_

--- a/Marlin/Voxel8_I2C_Commands.h
+++ b/Marlin/Voxel8_I2C_Commands.h
@@ -31,6 +31,7 @@
 #define SET_LED_WHITE_PWM       0x03
 #define SET_LED_RED_PWM         0x04
 #define SET_LED_UV_PWM          0x05
+
 #define EEPROM_WRITE            0x06
 #define EEPROM_READ             0x07
 #define EEPROM_READ_SERIAL      0x08
@@ -40,7 +41,13 @@
 #define EEPROM_READ_PRGMR       0x12
 #define EEPROM_READ_ERR         0x13
 #define EEPROM_READ_FRMWRE      0x14
+
+#define GET_GPIO_V_SENSE        0x20
+#define GET_GPIO_SWITCH         0x21
+
 #define CLEAR_ERROR             0x15
+
+#define EEPROM_READ_TEMP        0x16
 
 //===========================================================================
 //============================= Public Functions ============================
@@ -75,7 +82,7 @@ void I2C__ToggleUV(uint8_t data);
 
 /**
  * Writes data to a specific EEPROM address on a cartridge
- * @parameter cartridge           Address of the target (cartridge)
+ * @parameter cartridge           Address of the target
  * @parameter address             The EEPROM address being written to
  * @parameter data                The data being written
  */
@@ -83,57 +90,70 @@ void I2C__EEPROMWrite(uint8_t cartridge, uint8_t eeprom_address, uint8_t data);
 
 /**
  * Reads data from a specific EEPROM address on a cartridge
- * @parameter cartridge           Address of the target (cartridge)
+ * @parameter cartridge           Address of the target
  * @parameter address             The EEPROM address being written to
  */ 
 void I2C__EEPROMRead(uint8_t cartridge, uint8_t address);
 
 /**
  * Read the serial number from a cartridge and print it on the serial port
- * @parameter cartridge           Address of the target (cartridge)
+ * @parameter cartridge           Address of the target
  */ 
 void I2C__GetSerial(uint8_t cartridge);
 
 /**
  * Read the number of the programmer used on a cartridge and print it on
  * the serial port
- * @parameter cartridge           Address of the target (cartridge)
+ * @parameter cartridge           Address of the target
  */ 
 void I2C__GetProgrammerStation(uint8_t cartridge);
 
 /**
  * Read the variety of cartridge and print it on the serial port
- * @parameter cartridge           Address of the target (cartridge)
+ * @parameter cartridge           Address of the target
  */ 
 void I2C__GetCartridgeType(uint8_t cartridge);
 
 /**
  * Read the size of the nozzle from cartridge and print it on the serial port
- * @parameter cartridge           Address of the target (cartridge)
+ * @parameter cartridge           Address of the target
  */ 
 void I2C__GetSize(uint8_t cartridge);
 
 /**
  * Read the material contained by a cartridge and print it on the serial port
- * @parameter cartridge           Address of the target (cartridge)
+ * @parameter cartridge           Address of the target
  */ 
 void I2C__GetMaterial(uint8_t cartridge);
 
 /**
  * Read the material contained by a cartridge and print it on the serial port
- * @parameter cartridge           Address of the target (cartridge)
+ * @parameter cartridge           Address of the target
  */ 
 void I2C__GetErrorCode(uint8_t cartridge);
 
 /**
  * Read the firmware version by a cartridge and print it on the serial port
- * @parameter cartridge           Address of the target (cartridge)
+ * @parameter cartridge           Address of the target
  */ 
 void I2C__GetFirmwareVersion(uint8_t cartridge);
 
 /**
- * Clear the error flag for a particular cartridge if it's set
+ * Read the voltage sense pin on a cartridge and print it on the serial port
  * @parameter cartridge           Address of the target (cartridge)
+ */ 
+void I2C__GetVoltageSense(uint8_t cartridge);
+
+/**
+ * Read the SYRINGE_ACTIVE pin on a pneumatics cartridge and print it on the 
+ * serial port
+ * @parameter cartridge           Address of the target (pneumatic cartridge)
+ */ 
+void I2C__GetGpioSwitch(uint8_t cartridge);
+
+/**
+ * Clear the error flag for a particular cartridge if it's set
+ * @parameter cartridge           Address of the target
  */ 
 void I2C__ClearError(uint8_t cartridge);
 


### PR DESCRIPTION
![title-spec-feat](https://cloud.githubusercontent.com/assets/3892443/15481399/380d2350-20f8-11e6-9814-35d12b2ff206.png)

## Addition I2C Commands for Peripherals

## There are several I2C commands on the cartridges that don't have corresponding queries on the Marlin Side. This implements a few of them with new G Codes that can be used with them. 

 M251: Returns VSense, which corresponds to the extruder on the FFF cartridge and the solenoid on the pneumatic cartridge 

M253: Returns whether the pneumatics cartridge syringe is activated.


### Requirements
- [x] Unit Test
- [x] Alignment run successfully
- [x] Approval 1
- [ ] Approval 2