### PR TITLE
Skip M109 delay when temperature is set to 0

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3690,7 +3690,7 @@ inline void gcode_M105() {
       serialprintPGM(PSTR(MSG_T_CARTRIDGE_REMOVED_HEATING));
       SERIAL_EOL;
       SERIAL_ECHOLN("// action:cancel");
-    } 
+    }
     else {
       if (setTargetedHotend(109)) return;
       if (marlin_debug_flags & DEBUG_DRYRUN) return;
@@ -3700,6 +3700,7 @@ inline void gcode_M105() {
       no_wait_for_cooling = code_seen('S');
       if (no_wait_for_cooling || code_seen('R')) {
         float temp = code_value();
+        if (temp == 0) return; // Skip 10-second wait if set to 0
         setTargetHotend(temp, target_extruder);
 #if ENABLED(DUAL_X_CARRIAGE)
         if (dual_x_carriage_mode == DXC_DUPLICATION_MODE &&


### PR DESCRIPTION
###### ![time-is-money](https://cloud.githubusercontent.com/assets/16328681/16056645/6dfcd9f8-3244-11e6-8ef4-2eb9e68074b9.jpg)

## Skip Unnecessary M109 Delay

Since M109's are now inserted at the beginning of a print by Euclid and not specified in a config preamble, a 10s delay is added anytime `M109 S0` pops up for a tool, whether that be silver/auger/anything else that doesn't involve heating... pretty annoying, so this simple fix prevents those unnecessary delays from occurring if the setpoint is 0.