### PR TITLE
Individual Solenoid Control

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5397,7 +5397,7 @@ inline void gcode_M303() {
       // Invalid Tool Number
       default:
         SERIAL_ECHO_START;
-        SERIAL_CHAR('T');
+        SERIAL_PROTOCOLPGM('T');
         SERIAL_PROTOCOL_F(tool, DEC);
         SERIAL_PROTOCOLPGM(" ");
         SERIAL_ECHOLNPGM(MSG_INVALID_SOLENOID);
@@ -5466,7 +5466,7 @@ inline void gcode_M303() {
       // Invalid Tool Number
       default:
         SERIAL_ECHO_START;
-        SERIAL_CHAR('T');
+        SERIAL_PROTOCOLPGM('T');
         SERIAL_PROTOCOL_F(tool, DEC);
         SERIAL_PROTOCOLPGM(" ");
         SERIAL_ECHOLNPGM(MSG_INVALID_SOLENOID);

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5415,7 +5415,8 @@ inline void gcode_M303() {
     int8_t solenoid_pin = ensure_solenoid(tool);
     // If solenoid exists, enable it
     if (solenoid_pin >= 0) {
-      OUT_WRITE(solenoid_pin, HIGH);
+      pinMode(solenoid_pin, OUTPUT);
+      digitalWrite(solenoid_pin, HIGH);
     }
   } // end enable_solenoid
 
@@ -5428,14 +5429,15 @@ inline void gcode_M303() {
     int8_t solenoid_pin = ensure_solenoid(tool);
     // If solenoid exists, disable it
     if (solenoid_pin >= 0) {
-      OUT_WRITE(pin, LOW);
+      pinMode(solenoid_pin, OUTPUT);
+      digitalWrite(solenoid_pin, LOW);
     }
   } // end disable solenoid
 
   /*
    * Disables all solenoids that exist
    */
-  static void disable_all_solenoids() {
+  void disable_all_solenoids() {
     #if HAS_SOLENOID_0
       OUT_WRITE(SOL0_PIN, LOW);
     #endif
@@ -5469,6 +5471,7 @@ inline void gcode_M303() {
         SERIAL_PROTOCOLPGM(" ");
         SERIAL_ECHOLNPGM(MSG_INVALID_SOLENOID);
         break;
+    }
   }
 
   /**

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5444,6 +5444,33 @@ inline void gcode_M303() {
     #endif
   } // end disabe_all_solenoids
 
+  static void report_solenoid_status(uint8_t tool) {
+    bool pin_status;
+    switch (tool) {
+      #if HAS_SOLENOID_0
+        case 0:
+          pin_status = digitalRead(SOL0_PIN);
+          SERIAL_PROTOCOLPGM("Solenoid 0 Status: ");
+          SERIAL_PROTOCOLLN(pin_status);
+          break;
+      #endif
+      #if HAS_SOLENOID_1
+        case 1:
+          pin_status = digitalRead(SOL1_PIN);
+          SERIAL_PROTOCOLPGM("Solenoid 1 Status: ");
+          SERIAL_PROTOCOLLN(pin_status);
+          break;
+      #endif
+      // Invalid Tool Number
+      default:
+        SERIAL_ECHO_START;
+        SERIAL_CHAR('T');
+        SERIAL_PROTOCOL_F(tool, DEC);
+        SERIAL_PROTOCOLPGM(" ");
+        SERIAL_ECHOLNPGM(MSG_INVALID_SOLENOID);
+        break;
+  }
+
   /**
    * M380: Enable solenoid on the active extruder
    */

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5375,14 +5375,74 @@ inline void gcode_M303() {
 
 #if ENABLED(PNEUMATICS)
 
-  void disable_all_solenoids() {
+  /*
+   * Ensures the existence of a particular solenoid.
+   * @param   tool  Tool number of solenoid being checked.
+   * @returns solenoid_pin  Pin number of solenoid,
+   *                        or -1 if it does not exist.
+   */
+  static int8_t ensure_solenoid(uint8_t tool) {
+    int8_t solenoid_pin = -1;
+    switch(tool) {
+      #if HAS_SOLENOID_0
+        case 0:
+          solenoid_pin = SOL0_PIN;
+          break;
+      #endif
+      #if HAS_SOLENOID_1
+        case 1:
+          solenoid_pin = SOL1_PIN;
+          break;
+      #endif
+      // Invalid Tool Number
+      default:
+        SERIAL_ECHO_START;
+        SERIAL_CHAR('T');
+        SERIAL_PROTOCOL_F(tool, DEC);
+        SERIAL_PROTOCOLPGM(" ");
+        SERIAL_ECHOLNPGM(MSG_INVALID_SOLENOID);
+        break;
+    }
+    return solenoid_pin;
+  } // end ensure_solenoid
+
+  /*
+   * Enables the specified solenoid if it exists.
+   * @param   tool  Tool number of the solenoid to enable.
+   */
+  static void enable_solenoid(uint8_t tool) {
+    // Check that solenoid exists (assumed that uC pin count < 128)
+    int8_t solenoid_pin = ensure_solenoid(tool);
+    // If solenoid exists, enable it
+    if (solenoid_pin >= 0) {
+      OUT_WRITE(solenoid_pin, HIGH);
+    }
+  } // end enable_solenoid
+
+  /*
+   * Disables the specified solenoid if it exists.
+   * @param   tool  Tool number of the solenoid to disable.
+   */
+  static void disable_solenoid(uint8_t tool) {
+    // Check that solenoid exists
+    int8_t solenoid_pin = ensure_solenoid(tool);
+    // If solenoid exists, disable it
+    if (solenoid_pin >= 0) {
+      OUT_WRITE(pin, LOW);
+    }
+  } // end disable solenoid
+
+  /*
+   * Disables all solenoids that exist
+   */
+  static void disable_all_solenoids() {
     #if HAS_SOLENOID_0
       OUT_WRITE(SOL0_PIN, LOW);
     #endif
     #if HAS_SOLENOID_1
       OUT_WRITE(SOL1_PIN, LOW);
     #endif
-  }
+  } // end disabe_all_solenoids
 
   /**
    * M380: Enable solenoid on the active extruder


### PR DESCRIPTION
![54056776](https://cloud.githubusercontent.com/assets/13026720/16062742/34832e10-3263-11e6-94e6-78211163af5f.jpg)


# Individual Solenoid Control

## Description
Previously, individual solenoids could be turned on, but they could not be individually turned off. This PR allows complete individual control of solenoids and refactors the implementation of the existing commands.

* M380 Turns on (opens) a solenoid (active tool unless T parameter specified, then turns on specified solenoid)
* M381 Turns off (closes) all solenoids (unless T parameter specified, then only turns off specified solenoid)

Functions were defined that present an abstraction layer between the implementation and the actions being performed, specifically `enable_solenoid()`, `disable_solenoid()`, `disable_all_solenoids()`, `report_solenoid_status()`, and `ensure_solenoid()`

This update is fully backwards-compatible with G-code that previously used M380/381 commands in the past. 

@kdumontnu @danthompson41 @jminardi @dreammaker just an FYI that this exists...


### Requirements
- [ ] Diagnostics Test
- [x] Alignment run successfully
- [x] Free Ram looks reasonable
- [x] Approval 1
- [x] Approval 2
