### PR TITLE
Bugfix - Stop heating when silver is removed

### DIFF
--- a/Marlin/Cartridge.cpp
+++ b/Marlin/Cartridge.cpp
@@ -61,6 +61,20 @@ bool Cartridge__Present(uint8_t cartridgeNumber) {
 }
 
 /**
+ * Checks to see if a cartridge is removed, using the defined cartridge
+ * addresses.
+ * @inputs     0 for Cartridge 0, 1 for Cartridge 1
+ * @returns    Returns true if the specified cartridge is removed
+ */
+bool Cartridge__Removed(uint8_t cartridgeNumber) {
+  uint8_t returnValue = false;
+  if (cartridgeNumber <= NUMBER_OF_CARTRIDGES) {
+    if (cartridgeStatus[cartridgeNumber] == REMOVED) returnValue = true;
+  }
+  return returnValue;
+}
+
+/**
 * Check to see if cartridges are present or absent. Flags internally if
 * one has been removed, or clears the removed flag if it's present.
 * The status of cartridge removal can be found with

--- a/Marlin/Cartridge.h
+++ b/Marlin/Cartridge.h
@@ -11,6 +11,15 @@
 #define MARLIN_CARTRIDGE_H_
 
 //===========================================================================
+//=============================== Definitions ===============================
+//===========================================================================
+
+#define NUMBER_OF_CARTRIDGES (2)
+#define CARTRIDGE_REMOVAL_HYSTERESIS_COUNT (250)
+#define FFF_INDEX (0)
+#define SILVER_INDEX (1)
+ 
+//===========================================================================
 //============================= Public Functions ============================
 //===========================================================================
 
@@ -20,6 +29,13 @@
  * @returns    Returns true if the specified cartridge is present
  */
   bool Cartridge__Present(uint8_t cartridgeAddress);
+
+/**
+ * Checks to see if a cartridge is removed, using the defined cartridge
+ * addresses.
+ * @returns    Returns true if the specified cartridge is removed
+ */
+  bool Cartridge__Removed(uint8_t cartridgeNumber);
 
 /**
  * This function checks to see if the FFF cartridge is removed,

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3734,12 +3734,12 @@ inline void gcode_M105() {
                (residency_start_ms >= 0 &&
                 (((unsigned int)(millis() - residency_start_ms)) <
                  (TEMP_RESIDENCY_TIME * 1000UL))))) &&
-             !Cartridge__FFFNotPresent())
+             !Cartridge__FFFNotPresent() && !Cartridge__Removed(SILVER_INDEX))
 #else
       while ((target_direction ? (isHeatingHotend(target_extruder))
                                : (isCoolingHotend(target_extruder) &&
                                   (no_wait_for_cooling == false))) &&
-             !Cartridge__FFFNotPresent())
+             !Cartridge__FFFNotPresent() && !Cartridge__Removed(SILVER_INDEX))
 #endif  // TEMP_RESIDENCY_TIME
 
       {  // while loop


### PR DESCRIPTION

![commander fs ex9ss](https://cloud.githubusercontent.com/assets/3892443/16670839/4a6657c0-446a-11e6-943f-8962ad1b5706.jpg)


## Bugfix - Stop heating when silver is removed

## Description

Right now, we get stuck in a loop when you're heating the FFF cartridge and remove the silver one. This should exit the loop immediately. Currently, you'll hang because we shut off heating and don't quit the loop. 


### Requirements
- [ ] Diagnostics Test
- [ ] Alignment run successfully
- [ ] Free Ram looks reasonable
- [ ] Approval 1
- [ ] Approval 2
