### PR TITLE
Bugfix - Heating loop doesn't cancel when silver cartridge is removed

### DIFF
--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -58,6 +58,7 @@ float current_pneumatic = 0.0;
 float current_regulator = 0.0;
 millis_t time_since_last_err[4] = { 0 };
 millis_t time_since_last_err_bed = 0;
+extern bool cancel_heatup;
 
 #if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
   int redundant_temperature_raw = 0;
@@ -1304,6 +1305,7 @@ void tp_init() {
 #endif // THERMAL_PROTECTION_HOTENDS || THERMAL_PROTECTION_BED
 
 void disable_all_heaters() {
+  cancel_heatup = true;
   for (int i=0; i<EXTRUDERS; i++) setTargetHotend(0, i);
   setTargetBed(0);
 


### PR DESCRIPTION
![commander fs ex9ss](https://cloud.githubusercontent.com/assets/3892443/16740023/0df586f4-476b-11e6-8d4d-e61d4ddb2c70.jpg)

## Bugfix - Heating loop doesn't cancel when silver cartridge is removed

## Description

Currently, removing the silver cartridge causes us to disable heating, but will not exit a heating loop (see M109) where we're waiting for the heater to reach temperature. This fix causes all calls to disable_all_heaters to cancel the loop, which is called when either cartridge is removed.

### Requirements
- [x] Diagnostics Test
- [x] Alignment run successfully
- [x] Free Ram looks reasonable
- [x] Approval 1
- [x] Approval 2

