### PR TITLE
Dt/enhancement increase pressure range for leak detection

### DIFF
--- a/Marlin/GCodes.h
+++ b/Marlin/GCodes.h
@@ -159,6 +159,7 @@ inline void gcode_M248() {
   if (hasS = code_seen('S')) {
     switch(int(code_value())) {
       case 0:
+      // Cartridge Check
         if (hasE = code_seen('E')) {
           switch(int(code_value())) {
             case 0:
@@ -174,6 +175,7 @@ inline void gcode_M248() {
         }
         break;
       case 1:
+      // Heated Bed Check
         if (hasE = code_seen('E')) {
           switch(int(code_value())) {
             case 0:
@@ -189,6 +191,7 @@ inline void gcode_M248() {
         }
         break;
       case 2:
+      // Regulator Protection
         if (hasE = code_seen('E')) {
           switch(int(code_value())) {
             case 0:

--- a/Marlin/GCodes.h
+++ b/Marlin/GCodes.h
@@ -143,4 +143,82 @@ inline void gcode_M272(void) {
   }
 }
 
+
+/*
+* M248 - Enable / Disable Protections
+*   S - 0 - 2   0 = Cartridge Check, 1 = Heated Bed Check, 2 = Pressure 
+*               Protections Check
+*   E - 0 - 1   1 = Enable, 0 = Disable
+*/
+inline void gcode_M248() {
+  // Used to see if we've been given arguments, and to warn you through the
+  // serial port if they're not seen.
+  bool hasS;
+  bool hasE;
+
+  if (hasS = code_seen('S')) {
+    switch(int(code_value())) {
+      case 0:
+        if (hasE = code_seen('E')) {
+          switch(int(code_value())) {
+            case 0:
+              Cartridge__SetPresentCheck(false);
+              break;
+            case 1:
+              Cartridge__SetPresentCheck(true);
+              break;
+            default:
+              SERIAL_PROTOCOLLNPGM("(E1) or (E0) not given");
+              return;
+          }
+        }
+        break;
+      case 1:
+        if (hasE = code_seen('E')) {
+          switch(int(code_value())) {
+            case 0:
+              HeatedBed__SetPresentCheck(false);
+              break;
+            case 1:
+              HeatedBed__SetPresentCheck(true);
+              break;
+            default:
+              SERIAL_PROTOCOLLNPGM("(E1) or (E0) not given");
+              return;
+          }
+        }
+        break;
+      case 2:
+        if (hasE = code_seen('E')) {
+          switch(int(code_value())) {
+            case 0:
+              Regulator__SetPressureProtections(false);
+              break;
+            case 1:
+              Regulator__SetPressureProtections(true);
+              break;
+            default:
+              SERIAL_PROTOCOLLNPGM("(E1) or (E0) not given");
+              return;
+          }
+        }
+        break;
+      default:
+        SERIAL_PROTOCOLLNPGM(
+            "Invalid S argument: S0 = Cartridge, S1 = HeatedBed, S2 = "
+            "Pneumatics");
+        return;
+    }
+  }
+
+  if (!hasS) {
+    SERIAL_PROTOCOLLNPGM(
+        "No S argument given: S0 = Cartridge, S1 = HeatedBed, S2 = "
+        "Pneumatics");
+    }
+    if (!hasE) {
+      SERIAL_PROTOCOLLNPGM("(E1) or (E0) not given");
+    }
+}
+
 #endif  // G_CODES_H_

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -55,8 +55,7 @@
 #include "Cartridge.h"
 #include "Voxel8_I2C_Commands.h"
 #include "HeatedBed.h"
-#include "GCodes.h"
-#include "GCodeUtility.h"
+
 
 #if ENABLED(EXT_ADC)
   #include "ADC.h"
@@ -82,6 +81,9 @@
   #include <SPI.h>
 #endif
 
+#include "GCodes.h"
+#include "GCodeUtility.h"
+ 
 /**
  * Look here for descriptions of G-codes:
  *  - http://linuxcnc.org/handbook/gcode/g-code.html
@@ -5043,63 +5045,6 @@ inline void gcode_M247() {
   I2C__ToggleUV(i2c_data);
 }
 
-/*
-* M248 - Enable / Disable Cartridge Present Check
-*   E - 0 - 1   1 = Enable, 0 = Disable
-*/
-inline void gcode_M248() {
-  // Used to see if we've been given arguments, and to warn you through the
-  // serial port if they're not seen.
-  bool hasE;
-
-  // Desired address for peripheral device
-  if (hasE = code_seen('E')) {
-    switch(int(code_value())) {
-      case 0:
-        Cartridge__SetPresentCheck(false);
-        break;
-      case 1:
-        Cartridge__SetPresentCheck(true);
-        break;
-      default:
-        SERIAL_ECHOLNPGM("(E1) or (E0) not given");
-        return;
-    }
-  }
-
-  if (!hasE){
-    SERIAL_ECHOLNPGM("(E1) or (E0) not given");
-    return;
-  }
-}
-
-/*
-* M249 - Enable / Disable Heated Bed Check
-*   E - 0 - 1   1 = Enable, 0 = Disable
-*/
-inline void gcode_M249() {
-  // Used to see if we've been given arguments, and to warn you through the
-  // serial port if they're not seen.
-  bool hasE;
-
-  // Desired address for peripheral device
-  if (hasE = code_seen('E')) {
-    switch(int(code_value())) {
-      case 0:
-        HeatedBed__SetPresentCheck(false);
-        break;
-      case 1:
-        HeatedBed__SetPresentCheck(true);
-        break;
-    }
-  }
-  
-  if (!hasE){
-    SERIAL_ECHOLNPGM("Enable (E1) or Disable (E0) not given");
-    return;
-  }
-}
-
 #if HAS_SERVOS
 
   /**
@@ -6602,12 +6547,8 @@ void process_next_command() {
         gcode_M245();
         break;
 
-      case 248: // M248 - Enable / Disable Cartridge Check
+      case 248: // M248 - Enable / Disable Protections  
         gcode_M248();
-        break;
-
-      case 249: // M249 - Enable / Disable Heated Bed Check
-        gcode_M249();
         break;
 
       case 251: // I2C Query Syringe Status:

--- a/Marlin/Regulator.cpp
+++ b/Marlin/Regulator.cpp
@@ -20,7 +20,7 @@
 
 static float current_target_pressure = 0;
 static bool  regulator_active = false;
-
+static bool  protectionsActive = true;
 //===========================================================================
 //====================== Private Functions Prototypes =======================
 //===========================================================================
@@ -69,8 +69,18 @@ void Regulator__SetOutputPressure(float desired_pressure) {
  * Updates the protection function, called regularly in the main loop.
  */
 void Regulator__Update() {
-  pressure_protection(current_target_pressure, pressureRegulator());
+  if (protectionsActive) {
+    pressure_protection(current_target_pressure, pressureRegulator());
+  }
 }
+
+ /** 
+  * Enables or disables pressure protections
+  * @value     true = enable, false = no check.
+  */
+  void Regulator__SetPressureProtections(bool value) {
+    protectionsActive = value;
+  }
 
 //===========================================================================
 //============================ Private Functions ============================

--- a/Marlin/Regulator.cpp
+++ b/Marlin/Regulator.cpp
@@ -133,7 +133,7 @@ static void pressure_protection(float target_pressure, float pressure) {
   
     // Calculate the conditions where we may enter an error. This is split into
     // two bands, to accomodate larger variable in higher pressures.
-    if (pressure <= REGULATOR_BAND_CROSSOVER_PSI) {
+    if (target_pressure <= REGULATOR_BAND_CROSSOVER_PSI) {
       regulatorUnder =
           (pressure <= (target_pressure - REGULATOR_PROTECTION_BAND_LOW));
       regulatorOver =

--- a/Marlin/Regulator.h
+++ b/Marlin/Regulator.h
@@ -32,12 +32,22 @@
     #define REG_OFFSET      0.0   // psi
     #define REG_HYSTERESIS  0.0   // psi
 #endif // E_REGULATOR_SENSOR
-#define REGULATOR_LOW_P 2
 
-#define REGULATOR_PROTECTION_TIME_S (5)
-#define REGULATOR_PROTECTION_BAND   (4)
+// The amount of time the pressure must be outside the pressure bounds to activate
+// the protection
+#define REGULATOR_PROTECTION_TIME_S    (5)
 
-#define REGULATOR_NOT_PRESENT_VALUE (110)
+// The regulator protection is divided into two bands, with lower PSI having a 
+// tighter tolerance on the acceptable pressure values. The crossover is set below,
+// and the plus / minus values acceptable are set with REGULATOR_PROTECTION_BAND_LOW
+// and REGULATOR_PROTECTION_BAND_HIGH. REGULATOR_NOT_PRESENT_VALUE attempts to 
+// identify when the system is running without a pneumatics sled present, and
+// REGULATOR_LOW_P allows the pressure to have greater resolution near 0 PSI.
+#define REGULATOR_BAND_CROSSOVER_PSI   (HOUSE_AIR_THRESH)
+#define REGULATOR_PROTECTION_BAND_LOW  (5)
+#define REGULATOR_PROTECTION_BAND_HIGH (10)
+#define REGULATOR_NOT_PRESENT_VALUE    (110)
+#define REGULATOR_LOW_P                (2)
 
 /*================================================================================*/
 /* Function Prototypes */

--- a/Marlin/Regulator.h
+++ b/Marlin/Regulator.h
@@ -58,11 +58,17 @@
  * @input desired_pressure  The pressure that the function is attempting to 
  *                          reach.
  */
-void Regulator__SetOutputPressure(float pressure);
+  void Regulator__SetOutputPressure(float pressure);
 
 /**
  * Updates the protection function, called regularly in the main loop.
  */
-void Regulator__Update();
+  void Regulator__Update();
+
+ /** 
+  * Enables or disables pressure protections
+  * @value     true = enable, false = no check.
+  */
+  void Regulator__SetPressureProtections(bool value);
 
 #endif


### PR DESCRIPTION
![aid690595-728px-increase-the-range-of-your-wifi-step-3](https://cloud.githubusercontent.com/assets/3892443/16883509/505c3630-4a92-11e6-8eb1-8e7a620dfc2d.jpg)


## Increase pressure range for leak detection

## Description

This breaks the existing leak detection ( PSI 4 + or -) into two ranges, allowing us to not trigger the protection at higher PSIS. Also modified M248 to allow us to toggle on/of all protections individually, instead of keeping seperate mcodes for each.



### Requirements
- [x] Diagnostics Test
- [x] Alignment run successfully
- [x] Free Ram looks reasonable
- [x] Approval 1
- [ ] Approval 2
