### PR TITLE
Change temperature residency timer to 1 second.

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -185,7 +185,7 @@ Here are some standard links for getting your machine calibrated:
 #define MAX_REDUNDANT_TEMP_SENSOR_DIFF 10
 
 // Actual temperature must be close to target for this long before M109 returns success
-#define TEMP_RESIDENCY_TIME 10  // (seconds)
+#define TEMP_RESIDENCY_TIME 1  // (seconds)
 #define TEMP_HYSTERESIS 3       // (degC) range of +/- temperatures considered "close" to the target one
 #define TEMP_WINDOW     1       // (degC) Window around target to start the residency timer x degC early.
 


### PR DESCRIPTION
###### Prerequisite funny picture here

## Change temperature residency timer to 1 second.

## Description

When doing M109, the default is to pause 10 seconds once the target temperature is reached. This makes it undesirable to do M109 as a precaution when starting a layer. Changing the timer to wait 1 second makes it less scary to insert an M109 whenever we want to ensure a certain temperature has been reached.

### Requirements
- [x] Diagnostics Test
- [x] Alignment run successfully
- [x] Free Ram looks reasonable
- [x] Approval 1 - Dan T
- [ ] Approval 2

