### PR TITLE
St/auger

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -361,7 +361,7 @@ Here are some standard links for getting your machine calibrated:
  * the firmware will halt as a safety precaution.
  */
 
-//#define THERMAL_PROTECTION_HOTENDS // Enable thermal protection for all extruders
+#define THERMAL_PROTECTION_HOTENDS // Enable thermal protection for all extruders
 //#define THERMAL_PROTECTION_BED     // Enable thermal protection for the heated bed
 
 //===========================================================================
@@ -382,7 +382,14 @@ Here are some standard links for getting your machine calibrated:
 //#define HOME_AT_BACK
 
 // Define this if you are using dual pneumatics
-#define DUAL_PNEUMATICS
+//#define DUAL_PNEUMATICS
+
+// Define this if you are using an auger tool
+//#define AUGER
+#if ENABLED(AUGER)
+  #define DUAL_PNEUMATICS
+  #undef THERMAL_PROTECTION_HOTENDS
+#endif
 
 // Define to prevent printing without heated bed.
 #define HEATED_BED_PRESENT_CHECK

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -85,7 +85,7 @@ Here are some standard links for getting your machine calibrated:
 
 // This defines the number of extruders
 // :[1,2,3,4]
-#define EXTRUDERS 2
+#define EXTRUDERS 3
 
 // Offset of the extruders (uncomment if using more than one and relying on firmware to position when changing).
 // The offset has to be X=0, Y=0 for the extruder 0 hotend (default extruder).
@@ -361,7 +361,7 @@ Here are some standard links for getting your machine calibrated:
  * the firmware will halt as a safety precaution.
  */
 
-#define THERMAL_PROTECTION_HOTENDS // Enable thermal protection for all extruders
+//#define THERMAL_PROTECTION_HOTENDS // Enable thermal protection for all extruders
 //#define THERMAL_PROTECTION_BED     // Enable thermal protection for the heated bed
 
 //===========================================================================
@@ -382,7 +382,7 @@ Here are some standard links for getting your machine calibrated:
 //#define HOME_AT_BACK
 
 // Define this if you are using dual pneumatics
-//#define DUAL_PNEUMATICS
+#define DUAL_PNEUMATICS
 
 // Define to prevent printing without heated bed.
 #define HEATED_BED_PRESENT_CHECK

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -384,13 +384,6 @@ Here are some standard links for getting your machine calibrated:
 // Define this if you are using dual pneumatics
 //#define DUAL_PNEUMATICS
 
-// Define this if you are using an auger tool
-//#define AUGER
-#if ENABLED(AUGER)
-  #define DUAL_PNEUMATICS
-  #undef THERMAL_PROTECTION_HOTENDS
-#endif
-
 // Define to prevent printing without heated bed.
 #define HEATED_BED_PRESENT_CHECK
  

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -303,11 +303,7 @@ Note the A4982 is set to be limited to 2A. This means the adjustable voltage ran
 Wv, to be entered into firmware or directly over SPI.
 Wv = (VRef / 1.66) * 255
 */
-#if ENABLED(AUGER)
-  #define DIGIPOT_MOTOR_CURRENT {135,135,191,60,135} // Values 0-255 (RAMBO 90 = ~0.75A, 185 = ~1.5A)
-#else
-  #define DIGIPOT_MOTOR_CURRENT {135,135,191,75,135} // Values 0-255 (RAMBO 90 = ~0.75A, 185 = ~1.5A)
-#endif
+#define DIGIPOT_MOTOR_CURRENT {135,135,191,75,135} // Values 0-255 (RAMBO 90 = ~0.75A, 185 = ~1.5A)
 
 // uncomment to enable an I2C based DIGIPOT like on the Azteeg X3 Pro
 //#define DIGIPOT_I2C

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -303,7 +303,11 @@ Note the A4982 is set to be limited to 2A. This means the adjustable voltage ran
 Wv, to be entered into firmware or directly over SPI.
 Wv = (VRef / 1.66) * 255
 */
-#define DIGIPOT_MOTOR_CURRENT {135,135,191,60,135} // Values 0-255 (RAMBO 90 = ~0.75A, 185 = ~1.5A)
+#if ENABLED(AUGER)
+  #define DIGIPOT_MOTOR_CURRENT {135,135,191,60,135} // Values 0-255 (RAMBO 90 = ~0.75A, 185 = ~1.5A)
+#else
+  #define DIGIPOT_MOTOR_CURRENT {135,135,191,75,135} // Values 0-255 (RAMBO 90 = ~0.75A, 185 = ~1.5A)
+#endif
 
 // uncomment to enable an I2C based DIGIPOT like on the Azteeg X3 Pro
 //#define DIGIPOT_I2C

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -303,7 +303,7 @@ Note the A4982 is set to be limited to 2A. This means the adjustable voltage ran
 Wv, to be entered into firmware or directly over SPI.
 Wv = (VRef / 1.66) * 255
 */
-#define DIGIPOT_MOTOR_CURRENT {135,135,191,75,135} // Values 0-255 (RAMBO 90 = ~0.75A, 185 = ~1.5A)
+#define DIGIPOT_MOTOR_CURRENT {135,135,191,60,135} // Values 0-255 (RAMBO 90 = ~0.75A, 185 = ~1.5A)
 
 // uncomment to enable an I2C based DIGIPOT like on the Azteeg X3 Pro
 //#define DIGIPOT_I2C

--- a/Marlin/pins_VOXEL8_GEN3C2.h
+++ b/Marlin/pins_VOXEL8_GEN3C2.h
@@ -141,6 +141,11 @@ DIGITAL POTENTIOMETER PINS
 #define E1_MS1_PIN              63
 #define E1_MS2_PIN              64
 
+#define E2_STEP_PIN             0
+#define E2_DIR_PIN              0
+#define E2_ENABLE_PIN           0
+#define HEATER_2_PIN            0
+
 /**********************************************************
   Fan Pins
   Fan_0 8
@@ -177,4 +182,3 @@ DIGITAL POTENTIOMETER PINS
 #ifdef DEBUG
   #define TEST_POINT_83_PIN     83
 #endif  // DEBUG
-    


### PR DESCRIPTION
## Auger Settings

Most of the previous auger settings (cartridge thermal protections disabled and motor current = 0.5A) can actually now be enabled on-the-fly via `M248 E0 S0` and `M907 E60`, leaving only the dummy E2 pin definitions for the UV tool... merging these definitions into master allows us to easily enable the auger+UV setup on any printer.