### PR TITLE
St/auger refactor

### DIFF
--- a/Marlin/Cartridge.cpp
+++ b/Marlin/Cartridge.cpp
@@ -36,6 +36,7 @@ typedef enum _CartridgeStatus { ABSENT = 0, PRESENT, REMOVED } CARTRIDGE_STATUS;
 static CARTRIDGE_STATUS cartridgeStatus[NUMBER_OF_CARTRIDGES];
 
 static bool cartridgeRemovalCheckEnabled = 1;
+static bool augerEnabled = 1;
 
 //===========================================================================
 //====================== Private Functions Prototypes =======================
@@ -154,6 +155,38 @@ void Cartridge__SetPresentCheck(bool value) {
  * @returns   Returns true if the check is active
  */
 bool Cartridge__GetPresentCheck(void) { return cartridgeRemovalCheckEnabled; }
+
+/**
+ * Enables or disables auger extrusion
+ * @value     true = enable, false = disable
+ */
+void Cartridge__SetAugerEnabled(bool value) {
+  const uint8_t motor_current[] = DIGIPOT_MOTOR_CURRENT;
+  float min_temp = EXTRUDE_MINTEMP;
+  if (value == true) {
+    min_temp = 0;
+    digipot_current(E_AXIS, AUGER_CURRENT);
+    SERIAL_PROTOCOLLNPGM("Auger extrusion enabled");
+  } else if (value == false) {
+    digipot_current(E_AXIS, motor_current[E_AXIS]);
+    SERIAL_PROTOCOLLNPGM("Auger extrusion disabled");
+  } else {
+    SERIAL_PROTOCOLLNPGM("Invalid value for toggling auger extrusion");
+    return;
+  }
+
+  augerEnabled = value;
+  Cartridge__SetPresentCheck(!augerEnabled);
+  #if ENABLED(PREVENT_DANGEROUS_EXTRUDE)
+    extrude_min_temp = min_temp;
+  #endif
+}
+
+/**
+ * Checks to see if auger extrusion is enabled
+ * @returns   Returns true if auger extrusion is enabled
+ */
+bool Cartridge__GetAugerEnabled(void) { return augerEnabled; }
 
 //===========================================================================
 //============================ Private Functions ============================

--- a/Marlin/Cartridge.cpp
+++ b/Marlin/Cartridge.cpp
@@ -36,7 +36,7 @@ typedef enum _CartridgeStatus { ABSENT = 0, PRESENT, REMOVED } CARTRIDGE_STATUS;
 static CARTRIDGE_STATUS cartridgeStatus[NUMBER_OF_CARTRIDGES];
 
 static bool cartridgeRemovalCheckEnabled = 1;
-static bool augerEnabled = 1;
+static bool augerEnabled = 0;
 
 //===========================================================================
 //====================== Private Functions Prototypes =======================

--- a/Marlin/Cartridge.h
+++ b/Marlin/Cartridge.h
@@ -65,4 +65,16 @@
   * @returns   Returns true if the check is active
   */
   bool Cartridge__GetPresentCheck(void);
+
+ /**
+  * Enables or disables auger extrusion
+  * @value     true = enable, false = disable
+  */
+  void Cartridge__SetAugerEnabled(bool value);
+
+ /**
+  * Checks to see if auger extrusion is enabled
+  * @returns   Returns true if auger extrusion is enabled
+  */
+  bool Cartridge__GetAugerEnabled(void);
 #endif  // MARLIN_CARTRIDGE_H_

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -381,9 +381,6 @@ Here are some standard links for getting your machine calibrated:
 // Define this if you don't want to home in  the center of the bed.
 //#define HOME_AT_BACK
 
-// Define this if you are using dual pneumatics
-//#define DUAL_PNEUMATICS
-
 // Define to prevent printing without heated bed.
 #define HEATED_BED_PRESENT_CHECK
  

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -304,6 +304,7 @@ Wv, to be entered into firmware or directly over SPI.
 Wv = (VRef / 1.66) * 255
 */
 #define DIGIPOT_MOTOR_CURRENT {135,135,191,75,135} // Values 0-255 (RAMBO 90 = ~0.75A, 185 = ~1.5A)
+#define AUGER_CURRENT 60
 
 // uncomment to enable an I2C based DIGIPOT like on the Azteeg X3 Pro
 //#define DIGIPOT_I2C

--- a/Marlin/GCodes.h
+++ b/Marlin/GCodes.h
@@ -143,6 +143,26 @@ inline void gcode_M272(void) {
   }
 }
 
+/**
+ * M277: Enable/disable auger extrusion (E0)
+ */
+inline void gcode_M277() {
+  if (code_seen('S')) {
+    switch(int(code_value())) {
+      case 0:
+        Cartridge__SetAugerEnabled(0);
+        break;
+      case 255:
+        Cartridge__SetAugerEnabled(1);
+        break;
+      default:
+        SERIAL_PROTOCOLLNPGM("Invalid code given");
+        return;
+    }
+  } else {
+    Cartridge__SetAugerEnabled(1);
+  }
+}
 
 /*
 * M248 - Enable / Disable Protections

--- a/Marlin/GCodes.h
+++ b/Marlin/GCodes.h
@@ -148,7 +148,7 @@ inline void gcode_M272(void) {
  */
 inline void gcode_M277() {
   if (code_seen('S')) {
-    switch(int(code_value())) {
+    switch(uint8_t(code_value())) {
       case 0:
         Cartridge__SetAugerEnabled(0);
         break;

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3262,7 +3262,7 @@ inline void gcode_M42() {
 
     for (uint8_t i = 0; i < COUNT(sensitive_pins); i++) {
       if (sensitive_pins[i] == pin_number) {
-        pin_number = -1;
+        if (!(auger_enabled && pin_number == SOL0_PIN)) pin_number = -1;
         break;
       }
     }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5300,11 +5300,11 @@ inline void gcode_M277() {
   Cartridge__SetPresentCheck(!(auger_enabled));
   if (auger_enabled) {
     set_extrude_min_temp(0);
-    digipot_current(3, AUGER_CURRENT);
+    digipot_current(E_AXIS, AUGER_CURRENT);
     SERIAL_PROTOCOLLNPGM("Auger extrusion enabled");
   } else {
     set_extrude_min_temp(EXTRUDE_MINTEMP);
-    digipot_current(3, DIGIPOT_MOTOR_CURRENT[3]);
+    digipot_current(E_AXIS, DIGIPOT_MOTOR_CURRENT[E_AXIS]);
     SERIAL_PROTOCOLLNPGM("Auger extrusion disabled");
   }
 }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5293,6 +5293,7 @@ void gcode_M241(long num_milliseconds) {
  * M277: Enable/disable auger extrusion (E0)
  */
 inline void gcode_M277() {
+  const uint8_t motor_current[] = DIGIPOT_MOTOR_CURRENT;
   float min_temp = EXTRUDE_MINTEMP;
   if (code_seen('S')) {
     switch(int(code_value())) {
@@ -5316,7 +5317,7 @@ inline void gcode_M277() {
     digipot_current(E_AXIS, AUGER_CURRENT);
     SERIAL_PROTOCOLLNPGM("Auger extrusion enabled");
   } else {
-    digipot_current(E_AXIS, DIGIPOT_MOTOR_CURRENT[E_AXIS]);
+    digipot_current(E_AXIS, motor_current[E_AXIS]);
     SERIAL_PROTOCOLLNPGM("Auger extrusion disabled");
   }
   #if ENABLED(PREVENT_DANGEROUS_EXTRUDE)

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5276,11 +5276,24 @@ void gcode_M241(long num_milliseconds) {
 
 #endif // HAS_LCD_CONTRAST
 
+#if ENABLED(PREVENT_DANGEROUS_EXTRUDE)
+
+  void set_extrude_min_temp(float temp) { extrude_min_temp = temp; }
+
+  /**
+   * M302: Allow cold extrudes, or set the minimum extrude S<temperature>.
+   */
+  inline void gcode_M302() {
+    set_extrude_min_temp(code_seen('S') ? code_value() : 0);
+  }
+
+#endif // PREVENT_DANGEROUS_EXTRUDE
 
 /**
  * M277: Enable/disable auger extrusion (E0)
  */
 inline void gcode_M277() {
+  float min_temp = EXTRUDE_MINTEMP;
   if (code_seen('S')) {
     switch(int(code_value())) {
       case 0:
@@ -5299,28 +5312,17 @@ inline void gcode_M277() {
 
   Cartridge__SetPresentCheck(!(auger_enabled));
   if (auger_enabled) {
-    set_extrude_min_temp(0);
+    min_temp = 0;
     digipot_current(E_AXIS, AUGER_CURRENT);
     SERIAL_PROTOCOLLNPGM("Auger extrusion enabled");
   } else {
-    set_extrude_min_temp(EXTRUDE_MINTEMP);
     digipot_current(E_AXIS, DIGIPOT_MOTOR_CURRENT[E_AXIS]);
     SERIAL_PROTOCOLLNPGM("Auger extrusion disabled");
   }
+  #if ENABLED(PREVENT_DANGEROUS_EXTRUDE)
+    set_extrude_min_temp(min_temp);
+  #endif
 }
-
-#if ENABLED(PREVENT_DANGEROUS_EXTRUDE)
-
-  void set_extrude_min_temp(float temp) { extrude_min_temp = temp; }
-
-  /**
-   * M302: Allow cold extrudes, or set the minimum extrude S<temperature>.
-   */
-  inline void gcode_M302() {
-    set_extrude_min_temp(code_seen('S') ? code_value() : 0);
-  }
-
-#endif // PREVENT_DANGEROUS_EXTRUDE
 
 /**
  * M303: PID relay autotune

--- a/Marlin/pins_VOXEL8_GEN3C2.h
+++ b/Marlin/pins_VOXEL8_GEN3C2.h
@@ -88,21 +88,13 @@ DIGITAL POTENTIOMETER PINS
 /*************************
 	     FFF PINS
 *************************/
-#if ENABLED(DUAL_PNEUMATICS)
-  #define HEATER_0_PIN          2
-#else
-  #define HEATER_0_PIN          CART0_SIG0_PIN
-#endif
+#define HEATER_0_PIN            CART0_SIG0_PIN
 #define HEATER_1_PIN            -1 // Set to CART1_SIG0_PIN to use FFF in CART1
 
 /*************************
   TEMPERATURE SENSE PINS
 *************************/
-#if ENABLED(DUAL_PNEUMATICS)
-  #define TEMP_0_PIN            -1
-#else
-  #define TEMP_0_PIN            6   // A6 Input Cart0 Therm
-#endif
+#define TEMP_0_PIN              6   // A6 Input Cart0 Therm
 #define TEMP_1_PIN              1   // A1 Input Cart1 Therm
 #define TEMP_2_PIN              -1
 
@@ -120,11 +112,7 @@ DIGITAL POTENTIOMETER PINS
     SOLENOID PINS
 *************************/
 #if ENABLED(PNEUMATICS)
-  #if ENABLED(DUAL_PNEUMATICS)
-    #define SOL0_PIN            5
-  #else
-    #define SOL0_PIN            -1 // Set to CART0_SIG0_PIN for pneumatics in CART0
-  #endif
+  #define SOL0_PIN              CART0_SIG0_PIN // Set to CART0_SIG0_PIN for pneumatics in CART0
   #define SOL1_PIN              CART1_SIG0_PIN
 #endif
 

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1515,10 +1515,12 @@ ISR(TIMER0_COMPB_vect) {
      */
     if (pwm_count == 0) {
       soft_pwm_0 = soft_pwm[0];
-      if (soft_pwm_0 > 0) {
-        WRITE_HEATER_0(1);
+      if (!Cartridge__GetAugerEnabled) {
+        if (soft_pwm_0 > 0) {
+          WRITE_HEATER_0(1);
+        }
+        else WRITE_HEATER_0P(0); // If HEATERS_PARALLEL should apply, change to WRITE_HEATER_0
       }
-      else WRITE_HEATER_0P(0); // If HEATERS_PARALLEL should apply, change to WRITE_HEATER_0
 
       #if (EXTRUDERS > 1 && HAS_HEATER_1)
         soft_pwm_1 = soft_pwm[1];
@@ -1543,7 +1545,7 @@ ISR(TIMER0_COMPB_vect) {
       #endif
     }
 
-    if (soft_pwm_0 < pwm_count) { WRITE_HEATER_0(0); }
+    if (soft_pwm_0 < pwm_count && !Cartridge__GetAugerEnabled) { WRITE_HEATER_0(0); }
     #if EXTRUDERS > 1 && HAS_HEATER_1
       if (soft_pwm_1 < pwm_count) WRITE_HEATER_1(0);
       #if EXTRUDERS > 2


### PR DESCRIPTION
![](https://cloud.githubusercontent.com/assets/16328681/18146220/8e6467fc-6f9c-11e6-89b4-c50cee6a4d2a.jpg)
## M277 - Auger Toggle Code

This allows us to enable (`M277`, `M277 S255`) or disable (`M277 S0`) auger extrusion on T0 without any need for flashing firmware changes; the code:

- drops E0 stepper current to 0.5A
- disables cartridge checking
- enables cold extrusions

Also included are a couple minor changes to the heater interrupt to prevent the solenoid defined at the same pin from being constantly turned off.

Behaving as expected with auger enabled on Pompous Pumpkin, just need someone with an FFF cartridge to try printing with auger disabled.