### PR TITLE
Rr/feature request cart status

### DIFF
--- a/Marlin/GCodes.h
+++ b/Marlin/GCodes.h
@@ -73,7 +73,7 @@ inline void gcode_M250() {
         }
         break;
       default:
-        SERIAL_ECHOLNPGM("Invalid tool number!")
+        SERIAL_ECHOLNPGM("Invalid tool number!");
     } // end switch
   }
   else {

--- a/Marlin/GCodes.h
+++ b/Marlin/GCodes.h
@@ -49,6 +49,40 @@
 //===========================================================================
 
 /*
+* M250: Output whether cartridge is present over serial connection
+*   Usage: M250 T0 or M250 T1 to query presence of cartridge 0 or 1,
+*   respectively.
+*/
+inline void gcode_M250() {
+  if (code_seen('T')) {
+    switch ((uint8_t)code_value()) {
+      case 0:
+        if (Cartridge__Present(0)) {
+          SERIAL_ECHOLNPGM("true");
+        }
+        else {
+          SERIAL_ECHOLNPGM("false");
+        }
+        break;
+      case 1:
+        if (Cartridge__Present(1)) {
+          SERIAL_ECHOLNPGM("true");
+        }
+        else {
+          SERIAL_ECHOLNPGM("false");
+        }
+        break;
+      default:
+        SERIAL_ECHOLNPGM("Invalid tool number!")
+    } // end switch
+  }
+  else {
+    SERIAL_ECHOLNPGM("No tool number given");
+  }
+}
+
+
+/*
 * M251: I2C Query Syringe Status, currently only valid for Cart 1
 */
 inline void gcode_M251() { I2C__GetGpioSwitch(CART1_ADDR); }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6737,6 +6737,10 @@ void process_next_command() {
         gcode_M248();
         break;
 
+      case 250: // M250 - Output whether cartridge is present over serial
+        gcode_M250();
+        break;
+
       case 251: // I2C Query Syringe Status:
         gcode_M251();
         break;


### PR DESCRIPTION
![cart](https://cloud.githubusercontent.com/assets/13026720/19370343/62c8904c-9179-11e6-9e41-d216aba74993.jpg)
## M250 - Request Cartridge Present Status

This is a very basic code that we could live without, but it does come in handy for mecode scripts that might need to know whether or not a cartridge is present.

Behaving as expected, passed alignment, ready to merrrrrge.

@pizzyflavin @danthompson41 @kdumontnu
### Requirements
- [x] Alignment run successfully
- [x] Free Ram looks reasonable
- [x] Approval 1
- [ ] Approval 2
